### PR TITLE
call out to $(MAKE) instead of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ native: $(filter %.cmxa,$(TARGETS))
 	:
 
 %:
-	make -C src $@
+	$(MAKE) -C src $@
 
 PREFIX ?= /usr/local
 LIBDIR ?= $(PREFIX)/lib


### PR DESCRIPTION
there are systems where make and $(MAKE) are different (especially if you use
GNU make extensions)