### PR TITLE
add expose value parsers in OpamParser

### DIFF
--- a/src/opamParser.mli
+++ b/src/opamParser.mli
@@ -10,16 +10,31 @@
 
 open OpamParserTypes
 
-(** Raw OpamBaseParser main entry point *)
+(** Raw OpamBaseParser entry points;
+
+    Providing a custom [lexbuf] argument allows you, for example, to
+    set the initial lexing position. For the first argument, you may
+    use the {!OpamLexer.token} lexing function:
+
+{[
+    let lexbuf = Lexing.from_string input in
+    lexbuf.Lexing.lex_curr_p <- current_position;
+    OpamParser.value OpamLexer.token lexbuf
+]}
+*)
 val main:
   (Lexing.lexbuf  -> OpamBaseParser.token) ->
   Lexing.lexbuf -> file_name -> opamfile
+val value:
+  (Lexing.lexbuf  -> OpamBaseParser.token) ->
+  Lexing.lexbuf -> value
 
+(** file parsers *)
 val string: string -> file_name -> opamfile
-
 val channel: in_channel -> file_name -> opamfile
-
 val file: file_name -> opamfile
 
-(** Parse a string to a single value *)
-val value_of_string: ?pos:Lexing.position -> string -> value
+(** value parsers *)
+val value_from_string: string -> file_name -> value
+val value_from_channel: in_channel -> file_name -> value
+val value_from_file: file_name -> value


### PR DESCRIPTION
Currently, writing a parser from strings to values requires accessing
OpamBaseParser directly, which is a bit unpleasant -- it feels like
one is going too low-level. The proposed PR gives the same interface
to value parsers than to main/opamfile parsers.

I think another option would be to say that it is fine for users to
rely on OpamBaseParser directly (in particular, the unified interface
expects filename arguments that do not necessarily make much sense
when parsing values; maybe it is over-engineered), but then this
should be properly documented, for example by having
a OpamBaseParser.mli file versioned in the repository?