### PR TITLE
CR fixes

### DIFF
--- a/src/opamLexer.mll
+++ b/src/opamLexer.mll
@@ -126,7 +126,7 @@ rule token = parse
 
 and string b = parse
 | '\"'    { () }
-| '\n'    { newline lexbuf ;
+| eol     { newline lexbuf ;
             Buffer.add_char b '\n'            ; string b lexbuf }
 | '\\'    { (match escape lexbuf with
             | Some c -> Buffer.add_char b c
@@ -137,7 +137,7 @@ and string b = parse
 
 and string_triple b = parse
 | "\"\"\""    { () }
-| '\n'    { newline lexbuf ;
+| eol     { newline lexbuf ;
             Buffer.add_char b '\n'            ; string_triple b lexbuf }
 | '\\'    { (match escape lexbuf with
             | Some c -> Buffer.add_char b c

--- a/src/opamLexer.mll
+++ b/src/opamLexer.mll
@@ -147,7 +147,7 @@ and string_triple b = parse
 | eof     { error "unterminated string" }
 
 and escape = parse
-| '\n' space *
+| eol space *
           { newline lexbuf; None }
 | ['\\' '\"' ''' 'n' 'r' 't' 'b' ' '] as c
           { Some (char_for_backslash c) }

--- a/src/opamLexer.mll
+++ b/src/opamLexer.mll
@@ -80,7 +80,9 @@ let buffer_rule r lb =
   Buffer.contents b
 }
 
-let space  = [' ' '\t' '\r']
+let eol = '\r'? '\n'
+
+let space  = [' ' '\t']
 
 let alpha  = ['a'-'z' 'A'-'Z']
 let digit  = ['0'-'9']
@@ -97,7 +99,7 @@ let int    = ('-'? ['0'-'9' '_']+)
 
 rule token = parse
 | space  { token lexbuf }
-| '\n'   { newline lexbuf; token lexbuf }
+| eol    { newline lexbuf; token lexbuf }
 | ":"    { COLON }
 | "{"    { LBRACE }
 | "}"    { RBRACE }

--- a/src/opamParser.ml
+++ b/src/opamParser.ml
@@ -22,7 +22,7 @@ let parse_from_channel parse_fun ic filename =
   parse_fun OpamLexer.token lexbuf
 
 let parse_from_file parse_fun filename =
-  let ic = open_in filename in
+  let ic = open_in_bin filename in
   try
     let r = parse_from_channel parse_fun ic filename in
     close_in ic;


### PR DESCRIPTION
This tidies the skipping of `\r` which was haphazardly included in the `space` regexp before. This means that `\r` is now only permitted just before `\n` (it shouldn't really be a general space character).

This also means that newlines can actually be escaped in strings - before this wouldn't have worked, since the `\r` would have followed the backslash.

In order to avoid the horror which is Warning 29 in the compiler, un-escaped newlines in strings are *always* read as though they were `\n`. opam doesn't provide precise location information from its lexer (**clarification**: by precise, I mean it only records the start of the token, so there are no ranges to worry about), so it has already avoided some of the other pitfalls of trying to report locations with CRLF files...!