### PR TITLE
Fix single-line comment regexp

### DIFF
--- a/src/opamLexer.mll
+++ b/src/opamLexer.mll
@@ -108,7 +108,8 @@ rule token = parse
 | '\"'   { STRING (buffer_rule string lexbuf) }
 | "\"\"\"" { STRING (buffer_rule string_triple lexbuf) }
 | "(*"   { comment 1 lexbuf; token lexbuf }
-| "#"    { comment_line lexbuf; token lexbuf }
+| '#' [^'\n']*
+         { token lexbuf }
 | "true" { BOOL true }
 | "false"{ BOOL false }
 | int    { INT (int_of_string (Lexing.lexeme lexbuf)) }
@@ -161,7 +162,3 @@ and comment n = parse
 | eof  { error "unterminated comment" }
 | '\n' { newline lexbuf; comment n lexbuf }
 | _    { comment n lexbuf }
-
-and comment_line = parse
-| [^'\n']* '\n' { newline lexbuf }
-| [^'\n']       { () }


### PR DESCRIPTION
Previously, given the following file with no EOL at EOF:

```
a: "a" # b: "b"
```

The lexer would erroneously return the tokens for `b: "b"`. I think originally this is just a typo in https://github.com/ocaml/opam/commit/ce3729312299b8813bd7d57d164d37aa65caede5 (which was for https://github.com/ocaml/opam/issues/621). The original regexp just needed a `*` or `+` on the final line. However, the use of a separate lexer seems unnecessary here (the only concern is to ensure that the `eof` token is not accidentally consumed), so I've eliminated the lexer entirely and substituted the "correct" regexp for line comments.

That said, may I ping @samoht in case I've missed something about the original intent of the change!