### PR TITLE
CRLF preservation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Default behaviour, for if core.autocrlf isn't set
+* text=auto
+
+appveyor.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@
 *.cmxa
 *.cmxs
 *.a
+*.lib
 *.o
+*.obj
+src/.depend

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  global:
+  - PACKAGE=opam-file-format
+  matrix:
+  - OCAML_VERSION=4.02
+  - OCAML_VERSION=4.03
+  - OCAML_VERSION=4.04
+  - OCAML_VERSION=4.05
+  - OCAML_VERSION=4.06
+os:
+  - linux
+  - osx

--- a/appveyor.cmd
+++ b/appveyor.cmd
@@ -1,0 +1,94 @@
+@rem ***********************************************************************
+@rem *                                                                     *
+@rem *                                 opam                                *
+@rem *                                                                     *
+@rem *                 David Allsopp, OCaml Labs, Cambridge.               *
+@rem *                                                                     *
+@rem *   Copyright 2018 MetaStack Solutions Ltd.                           *
+@rem *                                                                     *
+@rem *   All rights reserved.  This file is distributed under the terms of *
+@rem *   the GNU Lesser General Public License version 2.1, with the       *
+@rem *   special exception on linking described in the file LICENSE.       *
+@rem *                                                                     *
+@rem ***********************************************************************
+
+@rem BE CAREFUL ALTERING THIS FILE TO ENSURE THAT ERRORS PROPAGATE
+@rem IF A COMMAND SHOULD FAIL IT PROBABLY NEEDS TO END WITH
+@rem   || exit /b 1
+@rem BASICALLY, DO THE TESTING IN BASH...
+
+@rem Do not call setlocal!
+@echo off
+
+goto %1
+
+goto :EOF
+
+:CheckPackage
+"%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc %1" | findstr %1 > nul
+if %ERRORLEVEL% equ 1 (
+  echo Cygwin package %1 will be installed
+  set CYGWIN_INSTALL_PACKAGES=%CYGWIN_INSTALL_PACKAGES%,%1
+)
+goto :EOF
+
+:UpgradeCygwin
+if "%CYGWIN_INSTALL_PACKAGES%" neq "" "%CYG_ROOT%\setup-%CYG_ARCH%.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages %CYGWIN_INSTALL_PACKAGES:~1% > nul
+for %%P in (%CYGWIN_COMMANDS%) do "%CYG_ROOT%\bin\bash.exe" -lc "%%P --help" > nul || set CYGWIN_UPGRADE_REQUIRED=1
+"%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc %CYGWIN_PACKAGES%"
+if %CYGWIN_UPGRADE_REQUIRED% equ 1 (
+  echo Cygwin package upgrade required - please go and drink coffee
+  "%CYG_ROOT%\setup-%CYG_ARCH%.exe" --quiet-mode --no-shortcuts --no-startmenu --no-desktop --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --upgrade-also > nul
+  "%CYG_ROOT%\bin\bash.exe" -lc "cygcheck -dc %CYGWIN_PACKAGES%"
+)
+goto :EOF
+
+:install
+set CYG_ROOT=C:\%CYG_ROOT%
+
+cd "%APPVEYOR_BUILD_FOLDER%"
+
+rem CYGWIN_PACKAGES is the list of required Cygwin packages (cygwin is included
+rem in the list just so that the Cygwin version is always displayed on the log).
+rem CYGWIN_COMMANDS is a corresponding command to run with --version to test
+rem whether the package works. This is used to verify whether the installation
+rem needs upgrading.
+set CYGWIN_PACKAGES=cygwin make patch diffutils tar unzip
+set CYGWIN_COMMANDS=cygcheck make patch diff tar unzip
+
+if "%OCAML_PORT%" equ "mingw" (
+  set CYGWIN_PACKAGES=%CYGWIN_PACKAGES% mingw64-i686-gcc-core
+  set CYGWIN_COMMANDS=%CYGWIN_COMMANDS% i686-w64-mingw32-core
+)
+if "%OCAML_PORT%" equ "mingw64" (
+  set CYGWIN_PACKAGES=%CYGWIN_PACKAGES% mingw64-x86_64-gcc-core
+  set CYGWIN_COMMANDS=%CYGWIN_COMMANDS% x86_64-w64-mingw32-core
+)
+if "%OCAML_PORT:~0,6%" equ "cygwin" (
+  set CYGWIN_PACKAGES=%CYGWIN_PACKAGES% flexdll gcc-core
+  set CYGWIN_COMMANDS=%CYGWIN_COMMANDS% flexlink gcc
+)
+
+set CYGWIN_INSTALL_PACKAGES=
+set CYGWIN_UPGRADE_REQUIRED=0
+
+for %%P in (%CYGWIN_PACKAGES%) do call :CheckPackage %%P
+call :UpgradeCygwin
+
+if "%OCAML_PORT%" equ "msvc64" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+if "%OCAML_PORT%" equ "msvc" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+
+"%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/appveyor.sh install" || exit /b 1
+
+set PATH=%OCAML_ROOT%\%OCAML_VERSION%\%OCAML_PORT%\bin;%PATH%
+
+goto :EOF
+
+:build
+"%CYG_ROOT%\bin\bash.exe" -lc "$APPVEYOR_BUILD_FOLDER/appveyor.sh build" || exit /b 1
+
+goto :EOF
+
+:test
+
+goto :EOF

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+TERM=st
+
+# Increment whenever the OCaml version or a package is updated to invalidate the caches
+SERIAL=1
+
+ROOT_CYG=$(echo $OCAML_ROOT| cygpath -f -)
+APPVEYOR_BUILD_FOLDER=$(echo $APPVEYOR_BUILD_FOLDER| cygpath -f -)
+
+ERRORS_ALLOWED=0
+function quietly_log {
+  if ! script --quiet --return --append --command "$1" $LOG_FILE > /dev/null 2>&1 ; then
+    sed -e 's/\d027\[K//g' \
+        -e 's/\d027\[m/\d027[0m/g' \
+        -e 's/\d027\[01\([m;]\)/\d027[1\1/g' $LOG_FILE
+    if ((ERRORS_ALLOWED)) ; then
+      return 1
+    else
+      exit 1
+    fi
+  fi
+}
+
+function msvs_promote_path {
+  if [[ ${1%64} = "msvc" ]] ; then
+    eval $($ROOT_CYG/msvs-promote-path)
+  fi
+}
+
+case "$1" in
+  install)
+    # @@DRA TODO This should be converted OCAML_ROOT to a regexp, not having C:\\\\OCaml hard coded!
+    if ! cat $APPVEYOR_BUILD_FOLDER/appveyor.yml | tr -d '\015' | sed -e '1,/^cache:/d' -e '/^$/,$d' | grep -q "^ \+- \+C:\\\\OCaml$" ; then
+      echo "$(tput setf 4)ERROR$(tput sgr0) C:\\OCaml doesn't appear to be cached in appveyor.yml"
+      exit 1
+    fi
+
+    if [[ ! -e $ROOT_CYG/$OCAML_VERSION/$OCAML_PORT/bin/ocamlopt.exe || ! -e $ROOT_CYG/$OCAML_VERSION/version || $(cat $ROOT_CYG/$OCAML_VERSION/version) != "$OCAML_VERSION-$SERIAL" ]] ; then
+      if [[ -e $ROOT_CYG/$OCAML_VERSION/version && $(cat $ROOT_CYG/$OCAML_VERSION/version) != "$OCAML_VERSION-$SERIAL" ]] ; then
+        echo "Build cache for $OCAML_VERSION has serial $(cat $ROOT_CYG/$OCAML_VERSION/version); should be $OCAML_VERSION-$SERIAL -- clearing"
+        rm -rf $ROOT_CYG/$OCAML_VERSION
+      elif [[ ! -e $ROOT_CYG/$OCAML_VERSION/version ]] ; then
+        rm -rf $ROOT_CYG/$OCAML_VERSION
+      fi
+
+      PREFIX=$ROOT_CYG/$OCAML_VERSION/$OCAML_PORT
+      ROOT=$(echo $OCAML_ROOT| cygpath -m -f -)/$OCAML_VERSION/$OCAML_PORT
+      OCAML_BRANCH=${OCAML_VERSION%.*}
+      OCAML_BRANCH=${OCAML_BRANCH/.}
+
+      if [[ ! -d $APPVEYOR_BUILD_FOLDER/../src ]] ; then
+        mkdir -p $APPVEYOR_BUILD_FOLDER/../src
+        cd $APPVEYOR_BUILD_FOLDER/../src
+        git clone https://github.com/ocaml/ocaml.git
+        cd ocaml
+        mkdir -p $PREFIX
+        cp tools/msvs-promote-path $ROOT_CYG/
+        cd ..
+        FLEXDLL_VER=0.37
+        appveyor DownloadFile "https://github.com/alainfrisch/flexdll/releases/download/$FLEXDLL_VER/flexdll-bin-$FLEXDLL_VER.zip" -FileName flexdll-bin-$FLEXDLL_VER.zip
+        [[ -e $PREFIX/../version ]] || echo $OCAML_VERSION-$SERIAL> $PREFIX/../version
+      fi
+
+      cd $APPVEYOR_BUILD_FOLDER/../src/ocaml
+      git checkout $OCAML_VERSION
+      git worktree add ../$OCAML_VERSION/$OCAML_PORT/ocaml -b build-$OCAML_VERSION-$OCAML_PORT
+      if [[ $OCAML_BRANCH -ge 403 ]] ; then
+        pushd ../$OCAML_VERSION/$OCAML_PORT/ocaml > /dev/null
+        git submodule update --init
+        popd > /dev/null
+      fi
+      cd ../$OCAML_VERSION/$OCAML_PORT/ocaml
+      if [[ ${OCAML_PORT%64} = "cygwin" ]] ; then
+        if [[ $OCAML_BRANCH -gt 406 ]] ; then
+          NO_ALT_RUNTIMES="-no-instrumented-runtime -no-debug-runtime"
+        else
+          NO_ALT_RUNTIMES=
+        fi
+        PRE_WORLD=
+        POST_WORLD=
+        MAKEFILE=
+        ./configure -prefix $PREFIX -no-ocamldoc -no-debugger $NO_ALT_RUNTIMES
+      else
+        if [[ $OCAML_BRANCH -ge 406 ]] ; then
+          cp config/s-nt.h byterun/caml/s.h
+          cp config/m-nt.h byterun/caml/m.h
+        else
+          cp config/s-nt.h config/s.h
+          cp config/m-nt.h config/m.h
+        fi
+        if [[ $OCAML_BRANCH -ge 405 ]] ; then
+          POST_WORLD=flexlink.opt
+          MAKEFILE=
+        else
+          POST_WORLD=
+          MAKEFILE=-f Makefile.nt
+        fi
+        if [[ $OCAML_BRANCH -lt 403 ]] ; then
+          mkdir -p $PREFIX/bin
+          pushd $PREFIX/bin > /dev/null
+          case $OCAML_PORT in
+            msvc)
+              MANIFEST=default.manifest;;
+            msvc64)
+              MANIFEST=default_amd64.manifest;;
+            *)
+              MANIFEST=;;
+          esac
+          unzip $APPVEYOR_BUILD_FOLDER/../src/flexdll-bin-$FLEXDLL_VER.zip flexdll_*$OCAML_PORT.* flexdll.h flexlink.exe $MANIFEST
+          popd > /dev/null
+          PRE_WORLD=
+        else
+          PRE_WORLD=flexdll
+        fi
+        sed -e "s|PREFIX=[^\r]*|PREFIX=$ROOT|" config/Makefile.$OCAML_PORT > config/Makefile
+        msvs_promote_path $OCAML_PORT
+      fi
+
+      LOG_FILE=OCaml-$OCAML_VERSION-$OCAML_PORT.log
+      echo "Building OCaml $OCAML_VERSION for $OCAML_PORT" | tee $LOG_FILE
+      echo "Please see $LOG_FILE for further information"
+      LOG_FILE="$APPVEYOR_BUILD_FOLDER/$LOG_FILE"
+      quietly_log "make $MAKEFILE $PRE_WORLD world.opt $POST_WORLD install"
+      # Remove unnecessary executables to keep the build cache size down
+      # These are removed here to ensure findlib doesn't configure itself
+      # to use .opt commands
+      if [[ $OCAML_BRANCH -ge 404 ]] ; then
+        if [[ ${OCAML_PORT%64} != "cygwin" ]] ; then
+          rm $PREFIX/bin/*.opt.exe
+        fi
+        rm $PREFIX/bin/*.byte.exe
+      else
+        for i in $PREFIX/bin/*.opt.exe ; do
+          rm ${i%.opt.exe}.exe
+          mv $i ${i%.opt.exe}.exe
+        done
+      fi
+      # Remove unnecessary commands to keep the build cache size down
+      rm -f $PREFIX/bin/{ocamlcp,ocamldebug,ocamldoc,ocamlmktop,ocamlobjinfo,ocamloptp,ocamlprof}.exe \
+            $PREFIX/lib/{expunge,extract_crc,objinfo_helper}.exe
+      # Remove unnecessary files
+      if [[ $OCAML_BRANCH -lt 405 && $OCAML_BRANCH -gt 402 ]] ; then
+        rm $PREFIX/*.txt
+      fi
+      find $PREFIX -name \*.cmt\* | xargs rm
+      find $PREFIX -name \*.ml\* | xargs rm
+      rm -f $PREFIX/lib/compiler-libs/*.cmx* $PREFIX/lib/compiler-libs/*.{lib,a} $PREFIX/lib/compiler-libs/ocamloptcomp.cma
+      echo "Complete"
+      appveyor PushArtifact $(echo $LOG_FILE| cygpath -m -f -)
+    fi
+    ;;
+  build)
+    if [[ -z $2 ]] ; then
+      set -o pipefail
+      SCRIPT=$(echo "$0"| cygpath -f -)
+      script -qec "\"$SCRIPT\" $1 script" | sed -e 's/\d027\[K//g' \
+                                                -e 's/\d027\[m/\d027[0m/g' \
+                                                -e 's/\d027\[01\([m;]\)/\d027[1\1/g'
+      exit $?
+    fi
+
+    msvs_promote_path $OCAML_PORT
+
+    make -C $APPVEYOR_BUILD_FOLDER all
+    ;;
+esac

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+platform:
+  - x64
+
+image: Visual Studio 2017
+
+clone_depth: 1
+
+environment:
+  global:
+    CYG_ROOT: cygwin64
+    CYG_ARCH: x86_64
+    OCAML_ROOT: C:\OCaml
+    OCAML_VERSION: 4.06.1
+    CYG_CACHE: C:\cygwin\var\cache\setup
+    CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
+  matrix:
+    - CYG_ROOT: cygwin
+      CYG_ARCH: x86
+      OCAML_PORT: cygwin
+    - CYG_ROOT: cygwin64
+      OCAML_PORT: cygwin64
+    - OCAML_PORT: msvc
+    - OCAML_PORT: msvc64
+    - OCAML_PORT: mingw
+    - OCAML_PORT: mingw64
+
+cache:
+  - C:\OCaml
+
+install:
+  - call "%APPVEYOR_BUILD_FOLDER%\appveyor.cmd" install
+
+build_script:
+  - call "%APPVEYOR_BUILD_FOLDER%\appveyor.cmd" build
+
+test_script:
+  - call "%APPVEYOR_BUILD_FOLDER%\appveyor.cmd" test
+
+# Uncomment this to enable Remote Desktop on the build worker at the end of the
+# build. The worker is available for the remainder of the allocated hour.
+#on_finish:
+#    - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/opam
+++ b/opam
@@ -1,7 +1,6 @@
 opam-version: "1.2"
 name: "opam-file-format"
 version: "2.0.0~rc2"
-synopsis: "Parser and printer for the opam file syntax"
 maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 license: "LGPL-2.1 with OCaml linking exception"

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ opam-file-format.cmxs: $(MODULES:%=%.cmx)
 
 .PHONY: clean
 clean:
-	rm -f *.cm* *.o *.a $(GENERATED) .depend
+	rm -f *.cm* *.o *.obj *.a *.lib $(GENERATED) .depend
 
 .depend: *.ml *.mli $(GENERATED)
 	ocamldep *.mli *.ml > .depend

--- a/src/opamLexer.mli
+++ b/src/opamLexer.mli
@@ -23,5 +23,13 @@ val pfxop: string -> pfxop
 
 val env_update_op: string -> env_update_op
 
+type state
+(** Internal state of the lexer. Created by {!new_state}, the state should
+    be passed in each subsequent call to {!token}. *)
 
-val token: Lexing.lexbuf -> OpamBaseParser.token
+val new_state: unit -> state
+(** Initialises the extra state required by the lexer. *)
+
+val token: state -> Lexing.lexbuf -> OpamBaseParser.token
+(** Returns the next token from a [Lexing.lexbuf] and updates the {!state}
+    (which would have been constructed by {!new_state}. *)

--- a/src/opamLexer.mli
+++ b/src/opamLexer.mli
@@ -9,19 +9,25 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** OPAM config file lexer *)
+(** opam format lexer *)
 
 open OpamParserTypes
 
 exception Error of string
+(** Raised on any lexing error with a description of the fault. Note that
+    [Failure "lexing: empty token"] is never raised by the lexer. *)
 
 val relop: string -> relop
+(** Inverse of {!OpamPrinter.relop} *)
 
 val logop: string -> logop
+(** Inverse of {!OpamPrinter.logop} *)
 
 val pfxop: string -> pfxop
+(** Inverse of {!OpamPrinter.pfxop} *)
 
 val env_update_op: string -> env_update_op
+(** Inverse of {!OpamPrinter.env_update_op} *)
 
 type state
 (** Internal state of the lexer. Created by {!new_state}, the state should

--- a/src/opamParser.ml
+++ b/src/opamParser.ml
@@ -13,13 +13,13 @@ let parse_from_string parse_fun str filename =
   let lexbuf = Lexing.from_string str in
   lexbuf.Lexing.lex_curr_p <-
     { lexbuf.Lexing.lex_curr_p with Lexing.pos_fname = filename };
-  parse_fun OpamLexer.token lexbuf
+  parse_fun (OpamLexer.token (OpamLexer.new_state ())) lexbuf
 
 let parse_from_channel parse_fun ic filename =
   let lexbuf = Lexing.from_channel ic in
   lexbuf.Lexing.lex_curr_p <-
     { lexbuf.Lexing.lex_curr_p with Lexing.pos_fname = filename };
-  parse_fun OpamLexer.token lexbuf
+  parse_fun (OpamLexer.token (OpamLexer.new_state ())) lexbuf
 
 let parse_from_file parse_fun filename =
   let ic = open_in_bin filename in
@@ -30,7 +30,7 @@ let parse_from_file parse_fun filename =
   with e -> close_in ic; raise e
 
 (** raw parser entry points *)
-let main = OpamBaseParser.main
+let main = OpamBaseParser.main ~default_eol_style:Sys.win32
 let value = OpamBaseParser.value
 
 (** file parsers *)

--- a/src/opamParser.mli
+++ b/src/opamParser.mli
@@ -8,13 +8,16 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** opam format parser *)
+
 open OpamParserTypes
 
-(** Raw OpamBaseParser entry points;
+(** {2 Raw OpamBaseParser entry points } *)
 
-    Providing a custom [lexbuf] argument allows you, for example, to
-    set the initial lexing position. For the first argument, you may
-    use the {!OpamLexer.token} lexing function:
+(**
+    Providing a custom [lexbuf] argument allows you, for example, to set the
+    initial lexing position. For the first argument, you may use the
+    {!OpamLexer.token} lexing function:
 
 {[
     let lexbuf = Lexing.from_string input in
@@ -22,19 +25,38 @@ open OpamParserTypes
     OpamParser.value OpamLexer.token lexbuf
 ]}
 *)
+
 val main:
   (Lexing.lexbuf  -> OpamBaseParser.token) ->
   Lexing.lexbuf -> file_name -> opamfile
+(** Principal parser: given a lexbuf and the filename it was read from, returns
+    an {!OpamParserTypes.opamfile} record parsed from it. *)
+
 val value:
   (Lexing.lexbuf  -> OpamBaseParser.token) ->
   Lexing.lexbuf -> value
+(** Lower-level function just returning a single {!OpamParserTypes.value} from
+    a given lexer. *)
 
-(** file parsers *)
+(** {2 File parsers } *)
 val string: string -> file_name -> opamfile
+(** Parse the content of a file already read to a string. Note that for
+    CRLF-detection to work on Windows, it is necessary to read the original file
+    using binary mode on Windows! *)
 val channel: in_channel -> file_name -> opamfile
+(** Parse the content of a file from an already-opened channel. Note that for
+    CRLF-detection to work on Windows, it is necessary for the channel to be
+    in binary mode! *)
 val file: file_name -> opamfile
+(** Parse the content of a file. The file is opened in binary mode, so
+    CRLF-detection works on all platforms. *)
 
-(** value parsers *)
+(** {2 [value] parsers } *)
 val value_from_string: string -> file_name -> value
+(** Parse the first value in the given string. [file_name] is used for lexer
+    positions. *)
 val value_from_channel: in_channel -> file_name -> value
+(** Parse the first value from the given channel. [file_name] is used for
+    lexer positions. *)
 val value_from_file: file_name -> value
+(** Parse the first value from the given file. *)

--- a/src/opamParserTypes.mli
+++ b/src/opamParserTypes.mli
@@ -25,6 +25,7 @@ type value =
   | Bool of pos * bool
   | Int of pos * int
   | String of pos * string
+      (** Note that newlines should always be encoded [\n] and never [\r\n] *)
   | Relop of pos * relop * value * value
   | Prefix_relop of pos * relop * value
   | Logop of pos * logop * value * value

--- a/src/opamParserTypes.mli
+++ b/src/opamParserTypes.mli
@@ -50,5 +50,6 @@ and opamfile_item =
 (** A file is a list of items and the filename *)
 type opamfile = {
   file_contents: opamfile_item list;
+  file_crlf    : bool;
   file_name    : file_name;
 }

--- a/src/opamParserTypes.mli
+++ b/src/opamParserTypes.mli
@@ -9,48 +9,78 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type relop = [ `Eq | `Neq | `Geq | `Gt | `Leq | `Lt ]
-type logop = [ `And | `Or ]
-type pfxop = [ `Not | `Defined ]
+(** Defines the types for the opam format lexer and parser *)
+
+(** Relational operators *)
+type relop = [ `Eq  (** [=] *)
+             | `Neq (** [!=] *)
+             | `Geq (** [>=] *)
+             | `Gt  (** [>] *)
+             | `Leq (** [<=] *)
+             | `Lt  (** [<] *)
+             ]
+(** Logical operators *)
+type logop = [ `And (** [&] *) | `Or (** [|] *) ]
+(** Prefix operators *)
+type pfxop = [ `Not (** [!] *) | `Defined (** [?] *) ]
 
 type file_name = string
 
-(** Source file positions: filename, line, column *)
+(** Source file positions: [(filename, line, column)] *)
 type pos = file_name * int * int
 
-type env_update_op = Eq | PlusEq | EqPlus | ColonEq | EqColon | EqPlusEq
+(** Environment variable update operators *)
+type env_update_op = Eq       (** [=] *)
+                   | PlusEq   (** [+=] *)
+                   | EqPlus   (** [=+] *)
+                   | ColonEq  (** [:=] *)
+                   | EqColon  (** [=:] *)
+                   | EqPlusEq (** [=+=] *)
 
 (** Base values *)
 type value =
   | Bool of pos * bool
+      (** [bool] atoms *)
   | Int of pos * int
+      (** [int] atoms *)
   | String of pos * string
-      (** Note that newlines should always be encoded [\n] and never [\r\n] *)
+      (** [string] atoms. Note that newlines should always be encoded [\n] and
+          never [\r\n] *)
   | Relop of pos * relop * value * value
+      (** Relational operators with two values (e.g. [os != "win32"]) *)
   | Prefix_relop of pos * relop * value
+      (** Relational operators in prefix position (e.g. [< "4.07.0"]) *)
   | Logop of pos * logop * value * value
+      (** Logical operators *)
   | Pfxop of pos * pfxop * value
+      (** Prefix operators *)
   | Ident of pos * string
+      (** Identifiers *)
   | List of pos * value list
+      (** Lists of values ([[x1 x2 ... x3]]) *)
   | Group of pos * value list
+      (** Groups of values ([(x1 x2 ... x3)]) *)
   | Option of pos * value * value list
+      (** Value with optional list ([x1 {x2 x3 x4}]) *)
   | Env_binding of pos * value * env_update_op * value
+      (** Environment variable binding ([FOO += "bar"]) *)
 
 (** An opamfile section *)
 type opamfile_section = {
-  section_kind  : string;
-  section_name  : string option;
-  section_items : opamfile_item list;
+  section_kind  : string;            (** Section kind (e.g. [extra-source]) *)
+  section_name  : string option;     (** Section name (e.g. ["myfork.patch"]) *)
+  section_items : opamfile_item list (** Content of the section *);
 }
 
 (** An opamfile is composed of sections and variable definitions *)
 and opamfile_item =
-  | Section of pos * opamfile_section
-  | Variable of pos * string * value
+  | Section of pos * opamfile_section (** e.g. [kind ["name"] { ... }] *)
+  | Variable of pos * string * value  (** e.g. [opam-version: "2.0"] *)
 
 (** A file is a list of items and the filename *)
 type opamfile = {
-  file_contents: opamfile_item list;
-  file_crlf    : bool;
-  file_name    : file_name;
+  file_contents: opamfile_item list; (** Content of the file *)
+  file_crlf    : bool;               (** Should the disk file be CRLF-encoded *)
+  file_name    : file_name;          (** Name of the disk file this record was
+                                         loaded from *)
 }

--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -206,19 +206,6 @@ let rec opamfile_item_equals i1 i2 = match i1, i2 with
   | _ -> false
 
 module Normalise = struct
-  (** OPAM normalised file format, for signatures:
-      - each top-level field on a single line
-      - file ends with a newline
-      - spaces only after [fieldname:], between elements in lists, before braced
-        options, between operators and their operands
-      - fields are sorted lexicographically by field name (using [String.compare])
-      - newlines in strings turned to ['\n'], backslashes and double quotes
-        escaped
-      - no comments (they don't appear in the internal file format anyway)
-      - fields containing an empty list, or a singleton list containing an empty
-        list, are not printed at all
-  *)
-
   let escape_string s =
     let len = String.length s in
     let buf = Buffer.create (len * 2) in

--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -53,6 +53,17 @@ let escape_string ?(triple=false) s =
   done;
   Buffer.contents buf
 
+let format_string fmt str =
+  let rec loop i =
+    match String.index_from str i '\n' with
+    | j ->
+        String.sub str i (j - i) |> Format.fprintf fmt "%s@\n";
+        loop (succ j)
+    | exception Not_found ->
+        String.sub str i (String.length str - i) |> Format.pp_print_string fmt
+  in
+  loop 0
+
 let rec format_value fmt = function
   | Relop (_,op,l,r) ->
     Format.fprintf fmt "@[<h>%a %s@ %a@]"
@@ -72,9 +83,9 @@ let rec format_value fmt = function
     if String.contains s '\n' then
       let s = escape_string ~triple:true s in
       if s.[0] = '\n' then
-        Format.fprintf fmt "\"\"\"%s\"\"\"" s
+        Format.fprintf fmt "\"\"\"%a\"\"\"" format_string s
       else
-        Format.fprintf fmt "\"\"\"\\\n%s\"\"\"" s
+        Format.fprintf fmt "\"\"\"\\@\n%a\"\"\"" format_string s
     else
       Format.fprintf fmt "\"%s\"" (escape_string s)
   | List (_, l) ->
@@ -136,11 +147,28 @@ let format_opamfile fmt f =
   format_items fmt f.file_contents;
   Format.pp_print_newline fmt ()
 
-let items l =
-  format_items Format.str_formatter l; Format.flush_str_formatter ()
+let items =
+  let buffer = Buffer.create 4096 in
+  let fmt = Format.formatter_of_buffer buffer in
+  let fns = Format.pp_get_formatter_out_functions fmt () in
+  fun crlf_eol l ->
+    let new_fns =
+      let out_newline =
+        if crlf_eol then
+          fun () -> Buffer.add_string Format.stdbuf "\r\n"
+        else
+          fns.out_newline
+      in
+      {fns with out_newline}
+    in
+    Format.pp_set_formatter_out_functions fmt new_fns;
+    let r = format_items fmt l; Format.pp_print_flush fmt (); Buffer.contents buffer in
+    Buffer.reset buffer;
+    Format.pp_set_formatter_out_functions fmt fns;
+    r
 
 let opamfile f =
-  items f.file_contents
+  items f.file_crlf f.file_contents
 
 let rec value_equals v1 v2 = match v1, v2 with
   | Bool (_, b1), Bool (_, b2) -> b1 = b2
@@ -255,7 +283,8 @@ module Normalise = struct
 end
 
 module Preserved = struct
-  let items txt orig f =
+  let items txt orig_crlf orig f =
+    let eol = if orig_crlf then "\r\n" else "\n" in
     let pos_index =
       let lines_index =
         let rec aux acc s =
@@ -304,7 +333,7 @@ module Preserved = struct
          | Some (Variable (_, _, v1)), f when value_equals v v1 ->
            aux (get_substring pos r :: acc) f r
          | Some item, f ->
-           aux ((items [item] ^ "\n") :: acc) f r
+           aux ((items orig_crlf [item] ^ eol) :: acc) f r
          | None, f ->
            aux acc f r)
       | Section (pos, {section_kind; section_name; _}) as sec :: r ->
@@ -312,12 +341,12 @@ module Preserved = struct
          | Some s, f when opamfile_item_equals sec s ->
            aux (get_substring pos r :: acc) f r
          | Some item, f ->
-           aux ((items [item] ^ "\n") :: acc) f r
+           aux ((items orig_crlf [item] ^ eol) :: acc) f r
          | None, f -> aux acc f r)
       | [] ->
         let remaining = match f with
           | [] -> []
-          | f -> [items f ^ "\n"]
+          | f -> [items orig_crlf f ^ eol]
         in
         List.rev_append acc remaining
     in
@@ -331,12 +360,12 @@ module Preserved = struct
     in
     let txt =
       let b = Buffer.create 4096 in
-      let ic = open_in orig_file in
+      let ic = open_in_bin orig_file in
       try while true do Buffer.add_channel b ic 4096 done; assert false with
       | End_of_file -> close_in ic; Buffer.contents b
       | e -> close_in ic; raise e
     in
     let orig = OpamParser.string txt orig_file in
-    items txt orig.file_contents f.file_contents
+    items txt orig.file_crlf orig.file_contents f.file_contents
 
 end

--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -69,10 +69,14 @@ let rec format_value fmt = function
   | Int (_,i)       -> Format.fprintf fmt "%d" i
   | Bool (_,b)      -> Format.fprintf fmt "%b" b
   | String (_,s)    ->
-    if String.contains s '\n'
-    then Format.fprintf fmt "\"\"\"\n%s\"\"\""
-        (escape_string ~triple:true s)
-    else Format.fprintf fmt "\"%s\"" (escape_string s)
+    if String.contains s '\n' then
+      let s = escape_string ~triple:true s in
+      if s.[0] = '\n' then
+        Format.fprintf fmt "\"\"\"%s\"\"\"" s
+      else
+        Format.fprintf fmt "\"\"\"\\\n%s\"\"\"" s
+    else
+      Format.fprintf fmt "\"%s\"" (escape_string s)
   | List (_, l) ->
     Format.fprintf fmt "@[<hv>[@;<0 2>@[<hv>%a@]@,]@]" format_values l
   | Group (_,g)     -> Format.fprintf fmt "@[<hv>(%a)@]" format_values g

--- a/src/opamPrinter.mli
+++ b/src/opamPrinter.mli
@@ -9,32 +9,68 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Functions for converting parsed opam files back to strings *)
+
 (** {2 Printers for the [value] and [opamfile] formats} *)
 
 open OpamParserTypes
 
 val relop: [< relop ] -> string
+(** Converts {!OpamParserTypes.relop} to its string representation
+    ([=], [!=], ..., [~]). *)
 
 val logop: [< logop ] -> string
+(** Converts {!OpamParserTypes.logop} to its string representation
+    ([&] and [|]). *)
 
 val pfxop: [< pfxop ] -> string
+(** Converts {!OpamParserTypes.pfxop} to its string representation
+    ([!] and [?]). *)
 
 val env_update_op: env_update_op -> string
+(** Converts {!OpamParserTypes.env_update_op} to its string representation
+    ([=], [+=], ..., [=:]). *)
 
 val value : value -> string
+(** Converts {!value} to a string {b always using LF-encoding of newlines}. *)
 
 val value_list: value list -> string
+(** Converts a list of {!value}s to a string {b always using LF-encoding of
+    newlines}. *)
 
 val items: bool -> opamfile_item list -> string
 (** [items crlf_eol l] converts [l] to a string. [crlf_eol] controls the
     conversion of line endings to CRLF. *)
 
 val opamfile: opamfile -> string
+(** Converts an {!opamfile} to a string, using the
+    {!OpamParserTypes.opamfile.file_crlf} field to determine how to encode line
+    endings. *)
 
 val format_opamfile: Format.formatter -> opamfile -> unit
+(** Writes an {!opamfile} to a [Format.formatter]. The function ensures that all
+    newlines are sent using [Format]'s break instructions (and so ultimately are
+    processed with the [out_newline] function of the formatter) but it is the
+    responsibility of the caller to ensure that the formatter is configured for
+    the required output, if necessary. *)
 
 (** {2 Normalised output for opam syntax files} *)
 
+(** opam normalised file format, for signatures.
+
+      - each top-level field on a single line
+      - newlines are LF-encoded (including on Windows)
+      - file ends with a newline
+      - spaces only after [fieldname:], between elements in lists, before braced
+        options, between operators and their operands
+      - fields are sorted lexicographically by field name
+        (using [String.compare])
+      - newlines in strings turned to ['\n'], backslashes and double quotes
+        escaped
+      - no comments (they don't appear in the internal file format anyway)
+      - fields containing an empty list, or a singleton list containing an empty
+        list, are not printed at all
+*)
 module Normalise : sig
   val escape_string : string -> string
   val value : value -> string
@@ -56,16 +92,17 @@ module Preserved : sig
       style of newlines for modified/new elements, the newlines for unmodified
       elements will always be as in [str], regardless of [orig_crlf]. *)
 
+  val opamfile: ?format_from:file_name -> opamfile -> string
   (** [opamfile f] converts [f] to string, respecting the layout and comments in
       the corresponding on-disk file for unmodified items. [format_from] can be
-      specified instead of using the filename specified in [f]. *)
-  val opamfile: ?format_from:file_name -> opamfile -> string
+      specified instead of using the filename specified in [f]. CRLF-encoding
+      is {b always} determined from the file (i.e. [f.file_crlf] is ignored). *)
 end
 
 (** {2 Random utility functions} *)
 
-(** Compares structurally, without considering file positions *)
 val value_equals: value -> value -> bool
-
 (** Compares structurally, without considering file positions *)
+
 val opamfile_item_equals: opamfile_item -> opamfile_item -> bool
+(** Compares structurally, without considering file positions *)

--- a/src/opamPrinter.mli
+++ b/src/opamPrinter.mli
@@ -25,7 +25,9 @@ val value : value -> string
 
 val value_list: value list -> string
 
-val items: opamfile_item list -> string
+val items: bool -> opamfile_item list -> string
+(** [items crlf_eol l] converts [l] to a string. [crlf_eol] controls the
+    conversion of line endings to CRLF. *)
 
 val opamfile: opamfile -> string
 
@@ -45,11 +47,14 @@ end
 (** {2 Format-preserving reprinter} *)
 
 module Preserved : sig
-  (** [items str orig_its its] converts [its] to string, while attempting to
-      preserve the layout and comments of the original [str] for unmodified
-      elements. The function assumes that [str] parses to the items
-      [orig_its]. *)
-  val items: string -> opamfile_item list -> opamfile_item list -> string
+  val items: string -> bool -> opamfile_item list -> opamfile_item list -> string
+  (** [items str orig_crlf orig_its its] converts [its] to a string, while
+      attempting to preserve the layout and comments of the original [str] for
+      unmodified elements. The function assumes that [str] parses to the items
+      [orig_its]. Note that although [orig_crlf] is intended to specify whether
+      the original file had CRLF-encoded newlines, in reality it controls the
+      style of newlines for modified/new elements, the newlines for unmodified
+      elements will always be as in [str], regardless of [orig_crlf]. *)
 
   (** [opamfile f] converts [f] to string, respecting the layout and comments in
       the corresponding on-disk file for unmodified items. [format_from] can be


### PR DESCRIPTION
This PR makes the following changes:
 - `OpamLexer` requires some additional state which allows it to track the line-endings of the file being parsed.
 - Based on this state, `OpamBaseParser`'s `EOF` token is augmented with a `bool option` indicating whether the file had CRLF-encoded line endings, LF-encoded line endings or a mixture.
 - `OpamParser` then treats mixed endings as CRLF on Windows and LF elsewhere and returns an `opamfile` record augmented with a `file_crlf` field.
 - `OpamPrinter` uses this information to control how it converts `opamfile` and related values back to strings.

Important notes:
 - The `Normalise` functions are unchanged - in particular, they use LF-endings on Windows
 - The `Preserved` functions now no longer LF-endings for changed entries and CRLF-endings for any unchanged values in a file which was CRLF-encoded
 - `opam format upgrade` should not magically convert all CRLF-encoded files to LF-encoded files.

This is still partially a work-in-progress, but is ready for initial review - in particular, I plan to add CI to this repo and some tests of these various behaviours and also produce a parallel PR in opam itself, as some changes are required there for CRLF-preservation.

In addition, the API is now documented.