### PR TITLE
Don't add newline at the start of triple-quotes

### DIFF
--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -70,7 +70,8 @@ let rec format_value fmt = function
   | Bool (_,b)      -> Format.fprintf fmt "%b" b
   | String (_,s)    ->
     if String.contains s '\n'
-    then Format.fprintf fmt "\"\"\"\n%s\"\"\""
+    then Format.fprintf fmt "\"\"\"%s%s\"\"\""
+        (if s.[0] = '\n' then "" else "\\\n")
         (escape_string ~triple:true s)
     else Format.fprintf fmt "\"%s\"" (escape_string s)
   | List (_, l) ->


### PR DESCRIPTION
This follows on from https://github.com/ocaml/opam/issues/3995, https://github.com/ocaml/opam-repository/pull/14910 and https://github.com/ocaml/opam-repository/pull/14912

`OpamPrinter.format_value` adds a newline after a `"""`, but this is not removed by the lexer. I think this has gone largely unnoticed (I'd spotted that synopsis + description was adding a blank line, but not looked into it much further).

This is one fix - the other would be to have the first newline after `"""` ignored. However, the whole escaping based on `\n` seems weird - the purpose of `"""` is to have strings where `"` doesn't need escaping?