### PR TITLE
2.1 readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ _build
 .merlin
 *.obj
 src/.depend
+src/opamBaseParser.ml
+src/opamBaseParser.mli
+src/opamLexer.ml

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/.depend
 src/opamBaseParser.ml
 src/opamBaseParser.mli
 src/opamLexer.ml
+src/META

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - PACKAGE=opam-file-format
+  - DEPOPTS=dune
+  - DUNE_PROFILE=dev
   matrix:
-  - OCAML_VERSION=4.02
+  - OCAML_VERSION=4.02 DUNE_PROFILE=release
   - OCAML_VERSION=4.03
   - OCAML_VERSION=4.04
   - OCAML_VERSION=4.05

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,6 @@ env:
 os:
   - linux
   - osx
+cache:
+    directories:
+    - $HOME/.opam

--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,7 @@
+2.1.0 [???]
+* Don't add a newline at the start of strings with newlines [#18 @dra27]
+* Report starting position of strings correctly [#19 @rjbou]
+* Add dune files [#13 @avsm @jonludlam @dra27]
+
+2.0.0 [1 Aug 2018]
+* Initial version

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-TARGETS = opam-file-format.cma opam-file-format.cmxa opam-file-format.cmxs META
+TARGETS = opam-file-format.cma opam-file-format.cmxa opam-file-format.cmxs
 
 all: $(TARGETS)
+	$(MAKE) -C src META
 
 byte: $(filter %.cma,$(TARGETS))
-	:
+	$(MAKE) -C src META
 
 native: $(filter %.cmxa,$(TARGETS))
-	:
+	$(MAKE) -C src META
 
 .PHONY: dune
 dune:

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,14 @@ byte: $(filter %.cma,$(TARGETS))
 native: $(filter %.cmxa,$(TARGETS))
 	:
 
+.PHONY: dune
+dune:
+	dune build --profile=dev @all
+
 %:
 	$(MAKE) -C src $@
+clean::
+	$(MAKE) -C src clean
 
 PREFIX ?= /usr/local
 LIBDIR ?= $(PREFIX)/lib
@@ -24,3 +30,6 @@ install:
 uninstall:
 	rm -f $(DESTDIR)$(LIBDIR)/opam-file-format/*
 	rmdir $(DESTDIR)$(LIBDIR)/opam-file-format
+
+clean::
+	rm -rf _build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS = opam-file-format.cma opam-file-format.cmxa opam-file-format.cmxs
+TARGETS = opam-file-format.cma opam-file-format.cmxa opam-file-format.cmxs META
 
 all: $(TARGETS)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# opam-file-format - Parser and printer for the opam file syntax
+
+[![TravisCI Build Status](https://travis-ci.org/ocaml/opam-file-format.svg?branch=master)](https://travis-ci.org/ocaml/opam-file-format)
+
+This library provides the parser and printer for the opam file syntax as a
+library with no dependencies. The package can be built either with GNU make
+or any version of [Dune](https://dune.build).
+
+Opam was created and is maintained by [OCamlPro](http://www.ocamlpro.com).
+
+## Copyright and license
+
+Copyright 2012-2016 OCamlPro
+Copyright 2012 INRIA
+
+All rights reserved. Opam is distributed under the terms of the GNU Lesser
+General Public License version 2.1, with the special exception on linking
+described in the file LICENSE.
+
+Opam is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.

--- a/opam-file-format.opam
+++ b/opam-file-format.opam
@@ -7,10 +7,9 @@ bug-reports: "https://github.com/ocaml/opam-file-format/issues"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-file-format"
 build: [
-  make
-  "byte" {!ocaml-native}
-  "all" {ocaml-native}
+  [make "byte" {!ocaml-native} "all" {ocaml-native}] {!dune:installed}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}] {dune:installed}
 ]
-install: [make "install" "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"] {!dune:installed}
 synopsis: "Parser and printer for the opam file syntax"
 depends: ["ocaml"]

--- a/opam-file-format.opam
+++ b/opam-file-format.opam
@@ -1,17 +1,16 @@
-opam-version: "1.2"
-name: "opam-file-format"
+opam-version: "2.0"
 version: "2.0.0"
-synopsis: "Parser and printer for the opam file syntax"
 maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
-license: "LGPL-2.1 with OCaml linking exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocaml/opam-file-format"
 build: [
   make
   "byte" {!ocaml-native}
   "all" {ocaml-native}
 ]
 install: [make "install" "PREFIX=%{prefix}%"]
-remove: ["rm" "-rf" "%{opam-file-format:lib}%"]
-dev-repo: "git+https://github.com/ocaml/opam-file-format"
+synopsis: "Parser and printer for the opam file syntax"
+depends: ["ocaml"]

--- a/opam-file-format.opam
+++ b/opam-file-format.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "2.0.0"
+version: "2.1.0"
 maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 homepage: "https://opam.ocaml.org"

--- a/opam-file-format.opam
+++ b/opam-file-format.opam
@@ -10,6 +10,7 @@ build: [
   [make "byte" {!ocaml-native} "all" {ocaml-native}] {!dune:installed}
   ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}] {dune:installed}
 ]
+depopts: "dune"
 install: [make "install" "PREFIX=%{prefix}%"] {!dune:installed}
 synopsis: "Parser and printer for the opam file syntax"
 depends: ["ocaml"]

--- a/src/META
+++ b/src/META
@@ -1,4 +1,0 @@
-version = "2.1.0"
-description = "Parser and printer for the opam file syntax"
-archive(byte) = "opam-file-format.cma"
-archive(native) = "opam-file-format.cmxa"

--- a/src/META
+++ b/src/META
@@ -1,4 +1,4 @@
-version = "2.0.0"
+version = "2.1.0"
 description = "Parser and printer for the opam file syntax"
 archive(byte) = "opam-file-format.cma"
 archive(native) = "opam-file-format.cmxa"

--- a/src/META.in
+++ b/src/META.in
@@ -1,0 +1,4 @@
+version = VERSION
+description = "Parser and printer for the opam file syntax"
+archive(byte) = "opam-file-format.cma"
+archive(native) = "opam-file-format.cmxa"

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,9 @@ opam-file-format.cmxa: $(MODULES:%=%.cmx)
 opam-file-format.cmxs: $(MODULES:%=%.cmx)
 	ocamlopt -shared $^ -o $@
 
+META: META.in ../opam-file-format.opam
+	sed -e 's/VERSION/$(shell sed -ne "s/^version: //p" ../opam-file-format.opam)/' $< > $@
+
 .PHONY: clean
 clean:
 	rm -f *.cm* *.o *.a $(GENERATED) .depend .merlin

--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ opam-file-format.cmxs: $(MODULES:%=%.cmx)
 
 .PHONY: clean
 clean:
-	rm -f *.cm* *.o *.a $(GENERATED) .depend
+	rm -f *.cm* *.o *.a $(GENERATED) .depend .merlin
 
 .depend: *.ml *.mli $(GENERATED)
 	ocamldep *.mli *.ml > .depend

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,8 @@ MODULES = $(sort $(basename $(wildcard *.ml *.mll *.mly)))
 
 GENERATED = $(patsubst %.mly,%.ml,$(wildcard *.mly)) \
             $(patsubst %.mly,%.mli,$(wildcard *.mly)) \
-            $(patsubst %.mll,%.ml,$(wildcard *.mll))
+            $(patsubst %.mll,%.ml,$(wildcard *.mll)) \
+	    META
 
 opam-file-format.cma: $(MODULES:%=%.cmo)
 	ocamlc -a $^ -o $@
@@ -30,8 +31,10 @@ opam-file-format.cmxa: $(MODULES:%=%.cmx)
 opam-file-format.cmxs: $(MODULES:%=%.cmx)
 	ocamlopt -shared $^ -o $@
 
-META: META.in ../opam-file-format.opam
-	sed -e 's/VERSION/$(shell sed -ne "s/^version: //p" ../opam-file-format.opam)/' $< > $@
+META: META.in ../opam-file-format.opam $(wildcard *.cm*)
+	sed -e 's/VERSION/$(shell sed -ne "s/^version: //p" ../opam-file-format.opam)/' \
+	    $(if $(wildcard *.cmx*),,-e '/archive(native)/d') \
+	    $(if $(wildcard *.cma),,-e '/archive(byte)/d') $< > $@
 
 .PHONY: clean
 clean:

--- a/src/opamParser.mli
+++ b/src/opamParser.mli
@@ -43,20 +43,25 @@ val string: string -> file_name -> opamfile
 (** Parse the content of a file already read to a string. Note that for
     CRLF-detection to work on Windows, it is necessary to read the original file
     using binary mode on Windows! *)
+
 val channel: in_channel -> file_name -> opamfile
 (** Parse the content of a file from an already-opened channel. Note that for
     CRLF-detection to work on Windows, it is necessary for the channel to be
     in binary mode! *)
+
 val file: file_name -> opamfile
 (** Parse the content of a file. The file is opened in binary mode, so
     CRLF-detection works on all platforms. *)
 
 (** {2 [value] parsers } *)
+
 val value_from_string: string -> file_name -> value
 (** Parse the first value in the given string. [file_name] is used for lexer
     positions. *)
+
 val value_from_channel: in_channel -> file_name -> value
 (** Parse the first value from the given channel. [file_name] is used for
     lexer positions. *)
+
 val value_from_file: file_name -> value
 (** Parse the first value from the given file. *)

--- a/src/opamParserTypes.mli
+++ b/src/opamParserTypes.mli
@@ -19,8 +19,10 @@ type relop = [ `Eq  (** [=] *)
              | `Leq (** [<=] *)
              | `Lt  (** [<] *)
              ]
+
 (** Logical operators *)
 type logop = [ `And (** [&] *) | `Or (** [|] *) ]
+
 (** Prefix operators *)
 type pfxop = [ `Not (** [!] *) | `Defined (** [?] *) ]
 

--- a/src/opamPrinter.mli
+++ b/src/opamPrinter.mli
@@ -41,9 +41,7 @@ val value_list: value list -> string
 val items: opamfile_item list -> string
 
 val opamfile: opamfile -> string
-(** Converts an {!opamfile} to a string, using the
-    {!OpamParserTypes.opamfile.file_crlf} field to determine how to encode line
-    endings. *)
+(** Converts an {!opamfile} to a string. *)
 
 val format_opamfile: Format.formatter -> opamfile -> unit
 (** Writes an {!opamfile} to a [Format.formatter]. The function ensures that all
@@ -90,8 +88,7 @@ module Preserved : sig
   val opamfile: ?format_from:file_name -> opamfile -> string
   (** [opamfile f] converts [f] to string, respecting the layout and comments in
       the corresponding on-disk file for unmodified items. [format_from] can be
-      specified instead of using the filename specified in [f]. CRLF-encoding
-      is {b always} determined from the file (i.e. [f.file_crlf] is ignored). *)
+      specified instead of using the filename specified in [f]. *)
 end
 
 (** {2 Random utility functions} *)


### PR DESCRIPTION
A slew of housekeeping:

- Update opam file to 2.0 format (and sync pertinent bits with opam-repsoitory)
- Add a `dune` target to the `Makefile`
- Couple of fixes to the API docs (two comments from #11 which should have remained there)
- Improved `META` file generation for the `Makefile` route
- `README` and `CHANGES`
- `dune` is added as a depopt so that Travis tests both the `Makefile` and the Dune overlays

I have used the version number 2.1, however we might want to consider whether that's correct - opam 2.0 should be updated to build with this (as it will allow opam-repository to benefit from the fix for strings containing newlines)