### PR TITLE
Add end position

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,17 +3,31 @@ all: opam-file-format.cmxa opam-file-format.cma
 %.ml: %.mll
 	ocamllex $<
 
+OCAML_VERSION:=$(shell ocamlc -vnum | tr -d '\r' | sed -e 's/+.*//' -e 's/\.//g')
+ifeq ($(OCAML_VERSION),)
+OCAML_VERSION:=0
+endif
+
+ifeq ($(shell test $(OCAML_VERSION) -ge 4022 || echo no-attributes),)
+PP=
+else
+PP=-pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//'
+endif
+
+show:
+	echo $(OCAML_VERSION)
+
 %.ml %.mli: %.mly
 	ocamlyacc $<
 
 %.cmi: %.mli
-	ocamlc -c $<
+	ocamlc -c $(PP) $<
 
 %.cmo: %.ml %.cmi
-	ocamlc -c $<
+	ocamlc -c $(PP) $<
 
 %.cmx: %.ml %.cmi
-	ocamlopt -c $<
+	ocamlopt -c $(PP) $<
 
 MODULES = $(sort $(basename $(wildcard *.ml *.mll *.mly)))
 
@@ -41,6 +55,6 @@ clean:
 	rm -f *.cm* *.o *.a $(GENERATED) .depend .merlin
 
 .depend: *.ml *.mli $(GENERATED)
-	ocamldep *.mli *.ml > .depend
+	ocamldep $(PP) *.mli *.ml > .depend
 
 -include .depend

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,16 @@
   (public_name opam-file-format)
   (synopsis "Parser and printer for the opam file syntax")
   (wrapped false)
+  (flags :standard (:include flags.sexp))
   (modules_without_implementation opamParserTypes))
+
+(rule
+  (with-stdout-to flags.ml
+    (echo "print_string (if String.sub Sys.ocaml_version 0 5 = \"4.02.\" then \"(-w -50)\" else \"()\")")))
+
+(rule
+  (with-stdout-to flags.sexp
+    (run ocaml %{dep:flags.ml})))
 
 (ocamlyacc opamBaseParser)
 (ocamllex opamLexer)

--- a/src/opamBaseParser.mly
+++ b/src/opamBaseParser.mly
@@ -11,7 +11,7 @@
 
 %{
 
-open OpamParserTypes
+open OpamParserTypes.FullPos
 
 (** Opam config file generic type parser *)
 
@@ -36,11 +36,11 @@ let get_pos n = get_pos_full ~s:n n
 %token LBRACE RBRACE
 %token COLON
 %token <int> INT
-%token <OpamParserTypes.relop_kind> RELOP
+%token <OpamParserTypes.FullPos.relop_kind> RELOP
 %token AND
 %token OR
-%token <OpamParserTypes.pfxop_kind> PFXOP
-%token <OpamParserTypes.env_update_op_kind> ENVOP
+%token <OpamParserTypes.FullPos.pfxop_kind> PFXOP
+%token <OpamParserTypes.FullPos.env_update_op_kind> ENVOP
 
 %left COLON
 %left ATOM
@@ -53,10 +53,10 @@ let get_pos n = get_pos_full ~s:n n
 %nonassoc URELOP
 
 %start main value
-%type <string -> OpamParserTypes.opamfile> main
-%type <OpamParserTypes.value> value
-%type <OpamParserTypes.value list> values
-%type <OpamParserTypes.opamfile_item> item
+%type <string -> OpamParserTypes.FullPos.opamfile> main
+%type <OpamParserTypes.FullPos.value> value
+%type <OpamParserTypes.FullPos.value list> values
+%type <OpamParserTypes.FullPos.opamfile_item> item
 
 %%
 

--- a/src/opamBaseParser.mly
+++ b/src/opamBaseParser.mly
@@ -15,11 +15,16 @@ open OpamParserTypes
 
 (** Opam config file generic type parser *)
 
-let get_pos n =
-  let pos = Parsing.rhs_start_pos n in
-  Lexing.(pos.pos_fname,
-          pos.pos_lnum,
-          pos.pos_cnum - pos.pos_bol)
+let get_pos_full ?(s=1) n =
+  let spos = Parsing.rhs_start_pos s in
+  let epos = Parsing.rhs_end_pos n in
+  Lexing.({
+      filename = spos.pos_fname;
+      start = spos.pos_lnum, spos.pos_cnum - spos.pos_bol;
+      stop = epos.pos_lnum, epos.pos_cnum - epos.pos_bol;
+    })
+
+let get_pos n = get_pos_full ~s:n n
 
 %}
 
@@ -31,11 +36,11 @@ let get_pos n =
 %token LBRACE RBRACE
 %token COLON
 %token <int> INT
-%token <OpamParserTypes.relop> RELOP
+%token <OpamParserTypes.relop_kind> RELOP
 %token AND
 %token OR
-%token <OpamParserTypes.pfxop> PFXOP
-%token <OpamParserTypes.env_update_op> ENVOP
+%token <OpamParserTypes.pfxop_kind> PFXOP
+%token <OpamParserTypes.env_update_op_kind> ENVOP
 
 %left COLON
 %left ATOM
@@ -50,6 +55,8 @@ let get_pos n =
 %start main value
 %type <string -> OpamParserTypes.opamfile> main
 %type <OpamParserTypes.value> value
+%type <OpamParserTypes.value list> values
+%type <OpamParserTypes.opamfile_item> item
 
 %%
 
@@ -64,28 +71,46 @@ items:
 ;
 
 item:
-| IDENT COLON value                { Variable (get_pos 1, $1, $3) }
+| IDENT COLON value                {
+  { pos = get_pos_full 3;
+    pelem =
+      Variable ({ pos = get_pos 1; pelem =  $1 }, $3);
+  }
+}
 | IDENT LBRACE items RBRACE {
-  Section (get_pos 1,
-           {section_kind=$1; section_name=None; section_items= $3})
+  { pos = get_pos_full 4;
+    pelem =
+      Section ({section_kind = { pos = get_pos 1; pelem = $1 };
+                section_name = None;
+                section_items =
+                  { pos = get_pos_full ~s:2 4; pelem = $3 };
+               })
+  }
 }
 | IDENT STRING LBRACE items RBRACE {
-  Section (get_pos 1,
-           {section_kind=$1; section_name=Some $2; section_items= $4})
+  { pos = get_pos_full 4;
+    pelem =
+      Section ({section_kind = { pos = get_pos 1; pelem = $1 };
+                section_name = Some { pos = get_pos 2; pelem = $2 };
+                section_items =
+                  { pos = get_pos_full ~s:2 4; pelem = $4 };
+               })
+  }
 }
 ;
 
 value:
 | atom            %prec ATOM { $1 }
-| LPAR values RPAR           { Group (get_pos 1,$2) }
-| LBRACKET values RBRACKET   { List (get_pos 1,$2) }
-| value LBRACE values RBRACE { Option (get_pos 2,$1, $3) }
-| value AND value            { Logop (get_pos 2,`And,$1,$3) }
-| value OR value             { Logop (get_pos 2,`Or,$1,$3) }
-| atom RELOP atom            { Relop (get_pos 2,$2,$1,$3) }
-| atom ENVOP atom            { Env_binding (get_pos 1,$1,$2,$3) }
-| PFXOP value                { Pfxop (get_pos 1,$1,$2) }
-| RELOP atom                 { Prefix_relop (get_pos 1,$1,$2) }
+| LPAR values RPAR           {{ pos = get_pos_full 3 ; pelem = Group { pos = get_pos_full ~s:1 3; pelem = $2 } }}
+| LBRACKET values RBRACKET   {{ pos = get_pos_full 3 ; pelem = List { pos = get_pos_full ~s:1 3; pelem = $2 } }}
+| value LBRACE values RBRACE {{ pos = get_pos_full 4 ;
+                                pelem = Option ($1, { pos = get_pos_full ~s:2 4; pelem = $3 }) }}
+| value AND value            {{ pos = get_pos_full 3 ; pelem = Logop ({ pos = get_pos 2 ; pelem = `And },$1,$3) }}
+| value OR value             {{ pos = get_pos_full 3 ; pelem = Logop ({ pos = get_pos 2 ; pelem = `Or },$1,$3) }}
+| atom RELOP atom            {{ pos = get_pos_full 3 ; pelem = Relop ({ pos = get_pos 2 ; pelem = $2 },$1,$3) }}
+| atom ENVOP atom            {{ pos = get_pos_full 3 ; pelem = Env_binding ($1,{ pos = get_pos 2 ; pelem = $2 },$3) }}
+| PFXOP value                {{ pos = get_pos_full 2 ; pelem = Pfxop ({ pos = get_pos 1 ; pelem = $1 },$2) }}
+| RELOP atom                 {{ pos = get_pos_full 2 ; pelem = Prefix_relop ({ pos = get_pos 1 ; pelem = $1 },$2) }}
 ;
 
 values:
@@ -94,10 +119,10 @@ values:
 ;
 
 atom:
-| IDENT                      { Ident (get_pos 1,$1) }
-| BOOL                       { Bool (get_pos 1,$1) }
-| INT                        { Int (get_pos 1,$1) }
-| STRING                     { String (get_pos 1,$1) }
+| IDENT                      {{ pos = get_pos 1 ; pelem = Ident $1 }}
+| BOOL                       {{ pos = get_pos 1 ; pelem = Bool $1 }}
+| INT                        {{ pos = get_pos 1 ; pelem = Int $1 }}
+| STRING                     {{ pos = get_pos 1 ; pelem = String $1 }}
 ;
 
 %%

--- a/src/opamLexer.mli
+++ b/src/opamLexer.mli
@@ -17,17 +17,28 @@ exception Error of string
 (** Raised on any lexing error with a description of the fault. Note that
     [Failure "lexing: empty token"] is never raised by the lexer. *)
 
-val relop: string -> relop_kind
+val relop: string -> relop
 (** Inverse of {!OpamPrinter.relop} *)
 
-val logop: string -> logop_kind
+val logop: string -> logop
 (** Inverse of {!OpamPrinter.logop} *)
 
-val pfxop: string -> pfxop_kind
+val pfxop: string -> pfxop
 (** Inverse of {!OpamPrinter.pfxop} *)
 
-val env_update_op: string -> env_update_op_kind
+val env_update_op: string -> env_update_op
 (** Inverse of {!OpamPrinter.env_update_op} *)
 
 
 val token: Lexing.lexbuf -> OpamBaseParser.token
+
+module FullPos : sig
+
+  open OpamParserTypes.FullPos
+
+  val relop: string -> relop_kind
+  val logop: string -> logop_kind
+  val pfxop: string -> pfxop_kind
+  val env_update_op: string -> env_update_op_kind
+
+end

--- a/src/opamLexer.mli
+++ b/src/opamLexer.mli
@@ -17,16 +17,16 @@ exception Error of string
 (** Raised on any lexing error with a description of the fault. Note that
     [Failure "lexing: empty token"] is never raised by the lexer. *)
 
-val relop: string -> relop
+val relop: string -> relop_kind
 (** Inverse of {!OpamPrinter.relop} *)
 
-val logop: string -> logop
+val logop: string -> logop_kind
 (** Inverse of {!OpamPrinter.logop} *)
 
-val pfxop: string -> pfxop
+val pfxop: string -> pfxop_kind
 (** Inverse of {!OpamPrinter.pfxop} *)
 
-val env_update_op: string -> env_update_op
+val env_update_op: string -> env_update_op_kind
 (** Inverse of {!OpamPrinter.env_update_op} *)
 
 

--- a/src/opamLexer.mli
+++ b/src/opamLexer.mli
@@ -17,32 +17,35 @@ exception Error of string
 (** Raised on any lexing error with a description of the fault. Note that
     [Failure "lexing: empty token"] is never raised by the lexer. *)
 
-val relop: string -> relop
-[@@ocaml.deprecated "Use OpamLexer.FullPos.relop instead."]
-(** Inverse of {!OpamPrinter.relop} *)
-
-val logop: string -> logop
-[@@ocaml.deprecated "Use OpamLexer.FullPos.logop instead."]
-(** Inverse of {!OpamPrinter.logop} *)
-
-val pfxop: string -> pfxop
-[@@ocaml.deprecated "Use OpamLexer.FullPos.pfxop instead."]
-(** Inverse of {!OpamPrinter.pfxop} *)
-
-val env_update_op: string -> env_update_op
-[@@ocaml.deprecated "Use OpamLexer.FullPos.env_update_op instead."]
-(** Inverse of {!OpamPrinter.env_update_op} *)
-
-
 val token: Lexing.lexbuf -> OpamBaseParser.token
 
+(** [OpamLexer] transitional module with full position types *)
 module FullPos : sig
 
   open OpamParserTypes.FullPos
 
   val relop: string -> relop_kind
+  (** Inverse of {!OpamPrinter.relop} *)
+
   val logop: string -> logop_kind
+  (** Inverse of {!OpamPrinter.logop} *)
+
   val pfxop: string -> pfxop_kind
+  (** Inverse of {!OpamPrinter.pfxop} *)
+
   val env_update_op: string -> env_update_op_kind
+  (** Inverse of {!OpamPrinter.env_update_op} *)
 
 end
+
+val relop: string -> relop
+[@@ocaml.deprecated "Use OpamLexer.FullPos.relop instead."]
+
+val logop: string -> logop
+[@@ocaml.deprecated "Use OpamLexer.FullPos.logop instead."]
+
+val pfxop: string -> pfxop
+[@@ocaml.deprecated "Use OpamLexer.FullPos.pfxop instead."]
+
+val env_update_op: string -> env_update_op
+[@@ocaml.deprecated "Use OpamLexer.FullPos.env_update_op instead."]

--- a/src/opamLexer.mli
+++ b/src/opamLexer.mli
@@ -18,15 +18,19 @@ exception Error of string
     [Failure "lexing: empty token"] is never raised by the lexer. *)
 
 val relop: string -> relop
+[@@ocaml.deprecated "Use OpamLexer.FullPos.relop instead."]
 (** Inverse of {!OpamPrinter.relop} *)
 
 val logop: string -> logop
+[@@ocaml.deprecated "Use OpamLexer.FullPos.logop instead."]
 (** Inverse of {!OpamPrinter.logop} *)
 
 val pfxop: string -> pfxop
+[@@ocaml.deprecated "Use OpamLexer.FullPos.pfxop instead."]
 (** Inverse of {!OpamPrinter.pfxop} *)
 
 val env_update_op: string -> env_update_op
+[@@ocaml.deprecated "Use OpamLexer.FullPos.env_update_op instead."]
 (** Inverse of {!OpamPrinter.env_update_op} *)
 
 

--- a/src/opamLexer.mll
+++ b/src/opamLexer.mll
@@ -40,7 +40,7 @@ let pfxop = function
   | "?" -> `Defined
   | x -> error "%S is not a valid prefix operator" x
 
-let env_update_op = function
+let env_update_op : string -> env_update_op = function
   | "=" -> Eq
   | "+=" -> PlusEq
   | "=+" -> EqPlus
@@ -48,6 +48,13 @@ let env_update_op = function
   | ":=" -> ColonEq
   | "=:" -> EqColon
   | x -> error "%S is not a valid environment update operator" x
+
+module FullPos = struct
+  let relop = relop
+  let logop = logop
+  let pfxop = pfxop
+  let env_update_op = env_update_op
+end
 
 let char_for_backslash = function
   | 'n' -> '\010'
@@ -119,11 +126,11 @@ rule token = parse
 | "false"{ BOOL false }
 | int    { INT (int_of_string (Lexing.lexeme lexbuf)) }
 | ident  { IDENT (Lexing.lexeme lexbuf) }
-| relop  { RELOP (relop (Lexing.lexeme lexbuf)) }
+| relop  { RELOP (FullPos.relop (Lexing.lexeme lexbuf)) }
 | '&'    { AND }
 | '|'    { OR }
-| pfxop  { PFXOP (pfxop (Lexing.lexeme lexbuf)) }
-| envop  { ENVOP (env_update_op (Lexing.lexeme lexbuf)) }
+| pfxop  { PFXOP (FullPos.pfxop (Lexing.lexeme lexbuf)) }
+| envop  { ENVOP (FullPos.env_update_op (Lexing.lexeme lexbuf)) }
 | eof    { EOF }
 | _      { let token = Lexing.lexeme lexbuf in
            error "'%s' is not a valid token" token }

--- a/src/opamParser.ml
+++ b/src/opamParser.ml
@@ -29,15 +29,78 @@ let parse_from_file parse_fun filename =
     r
   with e -> close_in ic; raise e
 
+(** file parsers *)
+let main' main filename lexer lexbuf = main lexer lexbuf filename
+let string main str filename = parse_from_string (main' main filename) str filename
+let channel main ic filename = parse_from_channel (main' main filename) ic filename
+let file main filename = parse_from_file (main' main filename) filename
+
+module FullPos = struct
+
+  open OpamParserTypes.FullPos
+
+  (** raw parser entry points *)
+  let main = OpamBaseParser.main
+  let value = OpamBaseParser.value
+
+  (** file parsers *)
+  let string = string main
+  let channel = channel main
+  let file = file main
+
+  (** value parsers *)
+  let value_from_string = parse_from_string value
+  let value_from_channel = parse_from_channel value
+  let value_from_file = parse_from_file value
+
+  (* Functions to transform simple pos to full pos *)
+  module S = OpamParserTypes
+
+  let to_pos e = (e.pos.filename, fst e.pos.start, snd e.pos.start)
+
+  let rec to_value v =
+    match v.pelem with
+    | Bool b -> S.Bool (to_pos v, b)
+    | Int i -> S.Int (to_pos v, i)
+    | String s -> S.String (to_pos v, s)
+    | Relop (r,v,v') -> S.Relop (to_pos r, r.pelem, to_value v, to_value v')
+    | Prefix_relop (r,v) -> S.Prefix_relop (to_pos r, r.pelem, to_value v)
+    | Logop (l,v,v') -> S.Logop (to_pos l, l.pelem, to_value v, to_value v')
+    | Pfxop (p,v) -> S.Pfxop (to_pos p, p.pelem, to_value v)
+    | Ident s -> S.Ident (to_pos v, s)
+    | List l -> S.List (to_pos l, List.map to_value l.pelem)
+    | Group g -> S.Group (to_pos g, List.map to_value g.pelem)
+    | Option (v,vl) -> S.Option (to_pos vl, to_value v, List.map to_value vl.pelem)
+    | Env_binding (v,o,v') -> S.Env_binding (to_pos o, to_value v, o.pelem, to_value v')
+
+  let rec to_section s =
+    { S.section_kind = s.section_kind.pelem;
+      S.section_name =
+        (match s.section_name with
+         | Some n -> Some n.pelem
+         | None -> None);
+      S.section_items = List.map to_item s.section_items.pelem
+    }
+  and to_item i =
+    match i.pelem with
+    | Section s -> S.Section (to_pos s.section_kind, to_section s)
+    | Variable (s, v) -> S.Variable (to_pos s, s.pelem, to_value v)
+
+  let to_opamfile o =
+    { S.file_contents = List.map to_item o.file_contents;
+      S.file_name = o.file_name
+    }
+
+end
+
 (** raw parser entry points *)
-let main = OpamBaseParser.main
-let value = OpamBaseParser.value
+let main f l fd = FullPos.to_opamfile (OpamBaseParser.main f l fd)
+let value f l = FullPos.to_value (OpamBaseParser.value f l)
 
 (** file parsers *)
-let main' filename lexer lexbuf = main lexer lexbuf filename
-let string str filename = parse_from_string (main' filename) str filename
-let channel ic filename = parse_from_channel (main' filename) ic filename
-let file filename = parse_from_file (main' filename) filename
+let string = string main
+let channel = channel main
+let file = file main
 
 (** value parsers *)
 let value_from_string = parse_from_string value

--- a/src/opamParser.mli
+++ b/src/opamParser.mli
@@ -29,41 +29,49 @@ open OpamParserTypes
 val main:
   (Lexing.lexbuf  -> OpamBaseParser.token) ->
   Lexing.lexbuf -> file_name -> opamfile
+[@@ocaml.deprecated "Use OpamParser.FullPos.main instead."]
 (** Principal parser: given a lexbuf and the filename it was read from, returns
     an {!OpamParserTypes.opamfile} record parsed from it. *)
 
 val value:
   (Lexing.lexbuf  -> OpamBaseParser.token) ->
   Lexing.lexbuf -> value
+[@@ocaml.deprecated "Use OpamParser.FullPos.value instead."]
 (** Lower-level function just returning a single {!OpamParserTypes.value} from
     a given lexer. *)
 
 (** {2 File parsers } *)
 val string: string -> file_name -> opamfile
+[@@ocaml.deprecated "Use OpamParser.FullPos.string instead."]
 (** Parse the content of a file already read to a string. Note that for
     CRLF-detection to work on Windows, it is necessary to read the original file
     using binary mode on Windows! *)
 
 val channel: in_channel -> file_name -> opamfile
+[@@ocaml.deprecated "Use OpamParser.FullPos.channel instead."]
 (** Parse the content of a file from an already-opened channel. Note that for
     CRLF-detection to work on Windows, it is necessary for the channel to be
     in binary mode! *)
 
 val file: file_name -> opamfile
+[@@ocaml.deprecated "Use OpamParser.FullPos.file instead."]
 (** Parse the content of a file. The file is opened in binary mode, so
     CRLF-detection works on all platforms. *)
 
 (** {2 [value] parsers } *)
 
 val value_from_string: string -> file_name -> value
+[@@ocaml.deprecated "Use OpamParser.FullPos.value_from_string instead."]
 (** Parse the first value in the given string. [file_name] is used for lexer
     positions. *)
 
 val value_from_channel: in_channel -> file_name -> value
+[@@ocaml.deprecated "Use OpamParser.FullPos.value_from_channel instead."]
 (** Parse the first value from the given channel. [file_name] is used for
     lexer positions. *)
 
 val value_from_file: file_name -> value
+[@@ocaml.deprecated "Use OpamParser.FullPos.value_from_file instead."]
 (** Parse the first value from the given file. *)
 
 module FullPos : sig

--- a/src/opamParser.mli
+++ b/src/opamParser.mli
@@ -65,3 +65,30 @@ val value_from_channel: in_channel -> file_name -> value
 
 val value_from_file: file_name -> value
 (** Parse the first value from the given file. *)
+
+module FullPos : sig
+
+  open OpamParserTypes.FullPos
+
+  val main:
+    (Lexing.lexbuf  -> OpamBaseParser.token) ->
+    Lexing.lexbuf -> file_name -> opamfile
+  val value:
+    (Lexing.lexbuf  -> OpamBaseParser.token) ->
+    Lexing.lexbuf -> value
+
+  val string: string -> file_name -> opamfile
+  val channel: in_channel -> file_name -> opamfile
+  val file: file_name -> opamfile
+
+  val value_from_string: string -> file_name -> value
+  val value_from_channel: in_channel -> file_name -> value
+  val value_from_file: file_name -> value
+
+  (** {3 Conversion functions, from full position to simple position (legacy)} *)
+  val to_value: value -> OpamParserTypes.value
+  val to_section: opamfile_section -> OpamParserTypes.opamfile_section
+  val to_item: opamfile_item -> OpamParserTypes.opamfile_item
+  val to_opamfile: opamfile -> OpamParserTypes.opamfile
+
+end

--- a/src/opamParser.mli
+++ b/src/opamParser.mli
@@ -12,91 +12,98 @@
 
 open OpamParserTypes
 
-(** {2 Raw OpamBaseParser entry points } *)
-
-(**
-    Providing a custom [lexbuf] argument allows you, for example, to set the
-    initial lexing position. For the first argument, you may use the
-    {!OpamLexer.token} lexing function:
-
-{[
-    let lexbuf = Lexing.from_string input in
-    lexbuf.Lexing.lex_curr_p <- current_position;
-    OpamParser.value OpamLexer.token lexbuf
-]}
-*)
-
-val main:
-  (Lexing.lexbuf  -> OpamBaseParser.token) ->
-  Lexing.lexbuf -> file_name -> opamfile
-[@@ocaml.deprecated "Use OpamParser.FullPos.main instead."]
-(** Principal parser: given a lexbuf and the filename it was read from, returns
-    an {!OpamParserTypes.opamfile} record parsed from it. *)
-
-val value:
-  (Lexing.lexbuf  -> OpamBaseParser.token) ->
-  Lexing.lexbuf -> value
-[@@ocaml.deprecated "Use OpamParser.FullPos.value instead."]
-(** Lower-level function just returning a single {!OpamParserTypes.value} from
-    a given lexer. *)
-
-(** {2 File parsers } *)
-val string: string -> file_name -> opamfile
-[@@ocaml.deprecated "Use OpamParser.FullPos.string instead."]
-(** Parse the content of a file already read to a string. Note that for
-    CRLF-detection to work on Windows, it is necessary to read the original file
-    using binary mode on Windows! *)
-
-val channel: in_channel -> file_name -> opamfile
-[@@ocaml.deprecated "Use OpamParser.FullPos.channel instead."]
-(** Parse the content of a file from an already-opened channel. Note that for
-    CRLF-detection to work on Windows, it is necessary for the channel to be
-    in binary mode! *)
-
-val file: file_name -> opamfile
-[@@ocaml.deprecated "Use OpamParser.FullPos.file instead."]
-(** Parse the content of a file. The file is opened in binary mode, so
-    CRLF-detection works on all platforms. *)
-
-(** {2 [value] parsers } *)
-
-val value_from_string: string -> file_name -> value
-[@@ocaml.deprecated "Use OpamParser.FullPos.value_from_string instead."]
-(** Parse the first value in the given string. [file_name] is used for lexer
-    positions. *)
-
-val value_from_channel: in_channel -> file_name -> value
-[@@ocaml.deprecated "Use OpamParser.FullPos.value_from_channel instead."]
-(** Parse the first value from the given channel. [file_name] is used for
-    lexer positions. *)
-
-val value_from_file: file_name -> value
-[@@ocaml.deprecated "Use OpamParser.FullPos.value_from_file instead."]
-(** Parse the first value from the given file. *)
-
+(** [OpamParser] transitional module with full position types *)
 module FullPos : sig
 
   open OpamParserTypes.FullPos
 
+  (** {2 Raw OpamBaseParser entry points } *)
+
+  (**
+      Providing a custom [lexbuf] argument allows you, for example, to set the
+      initial lexing position. For the first argument, you may use the
+      {!OpamLexer.token} lexing function:
+
+     {[
+       let lexbuf = Lexing.from_string input in
+       lexbuf.Lexing.lex_curr_p <- current_position;
+       OpamParser.value OpamLexer.token lexbuf
+     ]}
+  *)
+
   val main:
     (Lexing.lexbuf  -> OpamBaseParser.token) ->
     Lexing.lexbuf -> file_name -> opamfile
+  (** Principal parser: given a lexbuf and the filename it was read from, returns
+      an {!OpamParserTypes.FullPos.opamfile} record parsed from it. *)
+
   val value:
     (Lexing.lexbuf  -> OpamBaseParser.token) ->
     Lexing.lexbuf -> value
+  (** Lower-level function just returning a single
+      {!OpamParserTypes.FullPos.value} from a given lexer. *)
+
+  (** {2 File parsers } *)
 
   val string: string -> file_name -> opamfile
+  (** Parse the content of a file already read to a string. Note that for
+      CRLF-detection to work on Windows, it is necessary to read the original file
+      using binary mode on Windows! *)
+
   val channel: in_channel -> file_name -> opamfile
+  (** Parse the content of a file from an already-opened channel. Note that for
+      CRLF-detection to work on Windows, it is necessary for the channel to be
+      in binary mode! *)
+
   val file: file_name -> opamfile
+  (** Parse the content of a file. The file is opened in binary mode, so
+      CRLF-detection works on all platforms. *)
+
+  (** {2 [value] parsers } *)
 
   val value_from_string: string -> file_name -> value
-  val value_from_channel: in_channel -> file_name -> value
-  val value_from_file: file_name -> value
+  (** Parse the first value in the given string. [file_name] is used for lexer
+      positions. *)
 
-  (** {3 Conversion functions, from full position to simple position (legacy)} *)
+  val value_from_channel: in_channel -> file_name -> value
+  (** Parse the first value from the given channel. [file_name] is used for
+      lexer positions. *)
+
+  val value_from_file: file_name -> value
+  (** Parse the first value from the given file. *)
+
+  (** {2 Conversion functions, from full position to simple position (legacy)} *)
+
   val to_value: value -> OpamParserTypes.value
   val to_section: opamfile_section -> OpamParserTypes.opamfile_section
   val to_item: opamfile_item -> OpamParserTypes.opamfile_item
   val to_opamfile: opamfile -> OpamParserTypes.opamfile
 
 end
+
+val main:
+  (Lexing.lexbuf  -> OpamBaseParser.token) ->
+  Lexing.lexbuf -> file_name -> opamfile
+[@@ocaml.deprecated "Use OpamParser.FullPos.main instead."]
+
+val value:
+  (Lexing.lexbuf  -> OpamBaseParser.token) ->
+  Lexing.lexbuf -> value
+[@@ocaml.deprecated "Use OpamParser.FullPos.value instead."]
+
+val string: string -> file_name -> opamfile
+[@@ocaml.deprecated "Use OpamParser.FullPos.string instead."]
+
+val channel: in_channel -> file_name -> opamfile
+[@@ocaml.deprecated "Use OpamParser.FullPos.channel instead."]
+val file: file_name -> opamfile
+[@@ocaml.deprecated "Use OpamParser.FullPos.file instead."]
+
+val value_from_string: string -> file_name -> value
+[@@ocaml.deprecated "Use OpamParser.FullPos.value_from_string instead."]
+
+val value_from_channel: in_channel -> file_name -> value
+[@@ocaml.deprecated "Use OpamParser.FullPos.value_from_channel instead."]
+
+val value_from_file: file_name -> value
+[@@ocaml.deprecated "Use OpamParser.FullPos.value_from_file instead."]

--- a/src/opamParserTypes.mli
+++ b/src/opamParserTypes.mli
@@ -45,7 +45,7 @@ type env_update_op = Eq       (** [=] *)
 module FullPos : sig
 
   (** Source file positions *)
-  type nonrec file_name = file_name
+  type file_name = string
 
   (** Full position *)
   type pos = {

--- a/src/opamParserTypes.mli
+++ b/src/opamParserTypes.mli
@@ -10,88 +10,136 @@
 (**************************************************************************)
 
 (** Defines the types for the opam format lexer and parser *)
+module Common: sig
 
-(** Source file positions *)
-type file_name = string
-type pos =
-  { filename: file_name;
-    start: int * int; (* line, column *)
-    stop: int * int; (* line, column *)
+  (** Relational operators *)
+  type relop = [ `Eq  (** [=] *)
+               | `Neq (** [!=] *)
+               | `Geq (** [>=] *)
+               | `Gt  (** [>] *)
+               | `Leq (** [<=] *)
+               | `Lt  (** [<] *)
+               ]
+
+  (** Logical operators *)
+  type logop = [ `And (** [&] *) | `Or (** [|] *) ]
+
+  (** Prefix operators *)
+  type pfxop = [ `Not (** [!] *) | `Defined (** [?] *) ]
+
+  type file_name = string
+
+  (** Source file positions: [(filename, line, column)] *)
+  type pos = file_name * int * int
+
+  (** Environment variable update operators *)
+  type env_update_op = Eq       (** [=] *)
+                     | PlusEq   (** [+=] *)
+                     | EqPlus   (** [=+] *)
+                     | ColonEq  (** [:=] *)
+                     | EqColon  (** [=:] *)
+                     | EqPlusEq (** [=+=] *)
+end
+
+module FullPos : sig
+
+  (** Source file positions *)
+  type file_name = Common.file_name
+  type pos =
+    { filename: file_name;
+      start: int * int; (* line, column *)
+      stop: int * int; (* line, column *)
+    }
+  type 'a with_pos =
+    { pelem : 'a;
+      pos : pos
+    }
+
+  type relop_kind = Common.relop
+  and rel_op = relop_kind with_pos
+
+  type logop_kind = Common.logop
+  and log_op = logop_kind with_pos
+
+  type pfxop_kind = Common.pfxop
+  and pfx_op = pfxop_kind with_pos
+
+  type env_update_op_kind = Common.env_update_op
+  and env_update_op = env_update_op_kind with_pos
+
+  (** Base values *)
+  type value_kind =
+    | Bool of bool
+    | Int of int
+    | String of string
+    | Relop of rel_op * value * value
+    | Prefix_relop of rel_op * value
+    | Logop of log_op * value * value
+    | Pfxop of pfx_op * value
+    | Ident of string
+    | List of value list with_pos
+    | Group of value list with_pos
+    | Option of value * value list with_pos
+    | Env_binding of value * env_update_op * value
+  and value = value_kind with_pos
+
+  type opamfile_section =
+    { section_kind  : string with_pos;
+      section_name  : string with_pos option;
+      section_items : opamfile_item list with_pos;
+    }
+  and opamfile_item_kind =
+    | Section of opamfile_section
+    | Variable of string with_pos * value
+  and opamfile_item = opamfile_item_kind with_pos
+
+  type opamfile = {
+    file_contents: opamfile_item list;
+    file_name    : file_name;
   }
-type 'a with_pos =
-  { pelem : 'a;
-    pos : pos
-  }
 
-(** Relational operators *)
-type relop_kind =
-  [ `Eq  (** [=] *)
-  | `Neq (** [!=] *)
-  | `Geq (** [>=] *)
-  | `Gt  (** [>] *)
-  | `Leq (** [<=] *)
-  | `Lt  (** [<] *)
-  ]
-and rel_op = relop_kind with_pos
+end
 
-(** Logical operators *)
-type logop_kind = [ `And (** [&] *) | `Or (** [|] *) ]
-and log_op = logop_kind with_pos
-
-(** Prefix operators *)
-type pfxop_kind = [ `Not (** [!] *) | `Defined (** [?] *) ]
-and pfx_op = pfxop_kind with_pos
-
-(** Environment variable update operators *)
-type env_update_op_kind =
-  | Eq       (** [=] *)
-  | PlusEq   (** [+=] *)
-  | EqPlus   (** [=+] *)
-  | ColonEq  (** [:=] *)
-  | EqColon  (** [=:] *)
-  | EqPlusEq (** [=+=] *)
-and env_update_op = env_update_op_kind with_pos
+include module type of struct include Common end
 
 (** Base values *)
-type value_kind =
-  | Bool of bool
-      (** [bool] atoms *)
-  | Int of int
-      (** [int] atoms *)
-  | String of string
-      (** [string] atoms *)
-  | Relop of rel_op * value * value
-      (** Relational operators with two values (e.g. [os != "win32"]) *)
-  | Prefix_relop of rel_op * value
-      (** Relational operators in prefix position (e.g. [< "4.07.0"]) *)
-  | Logop of log_op * value * value
-      (** Logical operators *)
-  | Pfxop of pfx_op * value
-      (** Prefix operators *)
-  | Ident of string
-      (** Identifiers *)
-  | List of value list with_pos
-      (** Lists of values ([[x1 x2 ... x3]]) *)
-  | Group of value list with_pos
-      (** Groups of values ([(x1 x2 ... x3)]) *)
-  | Option of value * value list with_pos
-      (** Value with optional list ([x1 {x2 x3 x4}]) *)
-  | Env_binding of value * env_update_op * value
-      (** Environment variable binding ([FOO += "bar"]) *)
-and value = value_kind with_pos
+type value =
+  | Bool of pos * bool
+  (** [bool] atoms *)
+  | Int of pos * int
+  (** [int] atoms *)
+  | String of pos * string
+  (** [string] atoms *)
+  | Relop of pos * relop * value * value
+  (** Relational operators with two values (e.g. [os != "win32"]) *)
+  | Prefix_relop of pos * relop * value
+  (** Relational operators in prefix position (e.g. [< "4.07.0"]) *)
+  | Logop of pos * logop * value * value
+  (** Logical operators *)
+  | Pfxop of pos * pfxop * value
+  (** Prefix operators *)
+  | Ident of pos * string
+  (** Identifiers *)
+  | List of pos * value list
+  (** Lists of values ([[x1 x2 ... x3]]) *)
+  | Group of pos * value list
+  (** Groups of values ([(x1 x2 ... x3)]) *)
+  | Option of pos * value * value list
+  (** Value with optional list ([x1 {x2 x3 x4}]) *)
+  | Env_binding of pos * value * env_update_op * value
+  (** Environment variable binding ([FOO += "bar"]) *)
 
 (** An opamfile section *)
-type opamfile_section =
-  { section_kind  : string with_pos;            (** Section kind (e.g. [extra-source]) *)
-    section_name  : string with_pos option;     (** Section name (e.g. ["myfork.patch"]) *)
-    section_items : opamfile_item list with_pos (** Content of the section *);
-  }
+type opamfile_section = {
+  section_kind  : string;            (** Section kind (e.g. [extra-source]) *)
+  section_name  : string option;     (** Section name (e.g. ["myfork.patch"]) *)
+  section_items : opamfile_item list (** Content of the section *);
+}
 
 (** An opamfile is composed of sections and variable definitions *)
-and opamfile_item_kind =
-  | Section of opamfile_section          (** e.g. [kind ["name"] { ... }] *)
-  | Variable of string with_pos * value  (** e.g. [opam-version: "2.0"] *)
-and opamfile_item = opamfile_item_kind with_pos
+and opamfile_item =
+  | Section of pos * opamfile_section (** e.g. [kind ["name"] { ... }] *)
+  | Variable of pos * string * value  (** e.g. [opam-version: "2.0"] *)
 
 (** A file is a list of items and the filename *)
 type opamfile = {

--- a/src/opamParserTypes.mli
+++ b/src/opamParserTypes.mli
@@ -12,42 +12,40 @@
 (** Defines the types for the opam format lexer and parser *)
 
 (** Type definitions used by the legacy and the new full position modules *)
-module Common: sig
 
-  (** Relational operators *)
-  type relop = [ `Eq  (** [=] *)
-               | `Neq (** [!=] *)
-               | `Geq (** [>=] *)
-               | `Gt  (** [>] *)
-               | `Leq (** [<=] *)
-               | `Lt  (** [<] *)
-               ]
+(** Relational operators *)
+type relop = [ `Eq  (** [=] *)
+             | `Neq (** [!=] *)
+             | `Geq (** [>=] *)
+             | `Gt  (** [>] *)
+             | `Leq (** [<=] *)
+             | `Lt  (** [<] *)
+             ]
 
-  (** Logical operators *)
-  type logop = [ `And (** [&] *) | `Or (** [|] *) ]
+(** Logical operators *)
+type logop = [ `And (** [&] *) | `Or (** [|] *) ]
 
-  (** Prefix operators *)
-  type pfxop = [ `Not (** [!] *) | `Defined (** [?] *) ]
+(** Prefix operators *)
+type pfxop = [ `Not (** [!] *) | `Defined (** [?] *) ]
 
-  type file_name = string
+type file_name = string
 
-  (** Source file positions: [(filename, line, column)] *)
-  type pos = file_name * int * int
+(** Source file positions: [(filename, line, column)] *)
+type pos = file_name * int * int
 
-  (** Environment variable update operators *)
-  type env_update_op = Eq       (** [=] *)
-                     | PlusEq   (** [+=] *)
-                     | EqPlus   (** [=+] *)
-                     | ColonEq  (** [:=] *)
-                     | EqColon  (** [=:] *)
-                     | EqPlusEq (** [=+=] *)
-end
+(** Environment variable update operators *)
+type env_update_op = Eq       (** [=] *)
+                   | PlusEq   (** [+=] *)
+                   | EqPlus   (** [=+] *)
+                   | ColonEq  (** [:=] *)
+                   | EqColon  (** [=:] *)
+                   | EqPlusEq (** [=+=] *)
 
 (** [OpamParserTypes] transitional module with full position types *)
 module FullPos : sig
 
   (** Source file positions *)
-  type file_name = Common.file_name
+  type nonrec file_name = file_name
 
   (** Full position *)
   type pos = {
@@ -63,17 +61,17 @@ module FullPos : sig
     pos : pos
   }
 
-  type relop_kind = Common.relop
-  and rel_op = relop_kind with_pos
+  type relop_kind = relop
+  type relop = relop_kind with_pos
 
-  type logop_kind = Common.logop
-  and log_op = logop_kind with_pos
+  type logop_kind = logop
+  type logop = logop_kind with_pos
 
-  type pfxop_kind = Common.pfxop
-  and pfx_op = pfxop_kind with_pos
+  type pfxop_kind = pfxop
+  type pfxop = pfxop_kind with_pos
 
-  type env_update_op_kind = Common.env_update_op
-  and env_update_op = env_update_op_kind with_pos
+  type env_update_op_kind = env_update_op
+  type env_update_op = env_update_op_kind with_pos
 
   (** Base values *)
   type value_kind =
@@ -83,13 +81,13 @@ module FullPos : sig
     (** [int] atoms *)
     | String of string
     (** [string] atoms *)
-    | Relop of rel_op * value * value
+    | Relop of relop * value * value
     (** Relational operators with two values (e.g. [os != "win32"]) *)
-    | Prefix_relop of rel_op * value
+    | Prefix_relop of relop * value
     (** Relational operators in prefix position (e.g. [< "4.07.0"]) *)
-    | Logop of log_op * value * value
+    | Logop of logop * value * value
     (** Logical operators *)
-    | Pfxop of pfx_op * value
+    | Pfxop of pfxop * value
     (** Prefix operators *)
     | Ident of string
     (** Identifiers *)
@@ -126,8 +124,6 @@ module FullPos : sig
   }
 
 end
-
-include module type of struct include Common end
 
 type value =
   | Bool of pos * bool

--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -11,7 +11,7 @@
 
 open OpamParserTypes
 
-let relop_kind = function
+let relop = function
   | `Eq  -> "="
   | `Neq -> "!="
   | `Geq -> ">="
@@ -20,29 +20,21 @@ let relop_kind = function
   | `Lt  -> "<"
   | `Sem -> "~"
 
-let relop r = relop_kind r.pelem
-
-let logop_kind = function
+let logop = function
   | `And -> "&"
   | `Or -> "|"
 
-let logop r = logop_kind r.pelem
-
-let pfxop_kind = function
+let pfxop = function
   | `Not -> "!"
   | `Defined -> "?"
 
-let pfxop r = pfxop_kind r.pelem
-
-let env_update_op_kind = function
+let env_update_op = function
   | Eq -> "="
   | PlusEq -> "+="
   | EqPlus -> "=+"
   | EqPlusEq -> "=+="
   | ColonEq -> ":="
   | EqColon -> "=:"
-
-let env_update_op r = env_update_op_kind r.pelem
 
 let escape_string ?(triple=false) s =
   let len = String.length s in
@@ -61,35 +53,33 @@ let escape_string ?(triple=false) s =
   done;
   Buffer.contents buf
 
-let rec format_value fmt v =
-  match v.pelem with
-  | Relop (op,l,r) ->
+let rec format_value fmt = function
+  | Relop (_,op,l,r) ->
     Format.fprintf fmt "@[<h>%a %s@ %a@]"
       format_value l (relop op) format_value r
-  | Logop (op,l,r) ->
+  | Logop (_,op,l,r) ->
     Format.fprintf fmt "@[<hv>%a %s@ %a@]"
       format_value l (logop op) format_value r
-  | Pfxop (op,r) ->
+  | Pfxop (_,op,r) ->
     Format.fprintf fmt "@[<h>%s%a@]" (pfxop op) format_value r
-  | Prefix_relop (op,r) ->
+  | Prefix_relop (_,op,r) ->
     Format.fprintf fmt "@[<h>%s@ %a@]"
       (relop op) format_value r
-  | Ident s -> Format.fprintf fmt "%s" s
-  | Int i -> Format.fprintf fmt "%d" i
-  | Bool b -> Format.fprintf fmt "%b" b
-  | String s ->
+  | Ident (_,s)     -> Format.fprintf fmt "%s" s
+  | Int (_,i)       -> Format.fprintf fmt "%d" i
+  | Bool (_,b)      -> Format.fprintf fmt "%b" b
+  | String (_,s)    ->
     if String.contains s '\n'
     then Format.fprintf fmt "\"\"\"%s%s\"\"\""
         (if s.[0] = '\n' then "" else "\\\n")
         (escape_string ~triple:true s)
     else Format.fprintf fmt "\"%s\"" (escape_string s)
-  | List l ->
-    Format.fprintf fmt "@[<hv>[@;<0 2>@[<hv>%a@]@,]@]" format_values l.pelem
-  | Group g -> Format.fprintf fmt "@[<hv>(%a)@]" format_values g.pelem
-  | Option (v,l) ->
-    Format.fprintf fmt "@[<hov 2>%a@ {@[<hv>%a@]}@]"
-      format_value v format_values l.pelem
-  | Env_binding (id,op,v) ->
+  | List (_, l) ->
+    Format.fprintf fmt "@[<hv>[@;<0 2>@[<hv>%a@]@,]@]" format_values l
+  | Group (_,g)     -> Format.fprintf fmt "@[<hv>(%a)@]" format_values g
+  | Option(_,v,l)   -> Format.fprintf fmt "@[<hov 2>%a@ {@[<hv>%a@]}@]"
+                         format_value v format_values l
+  | Env_binding (_,id,op,v) ->
     Format.fprintf fmt "@[<h>%a %s@ %a@]"
       format_value id (env_update_op op) format_value v
 
@@ -105,43 +95,31 @@ let value v =
   format_value Format.str_formatter v; Format.flush_str_formatter ()
 
 let value_list vl =
-  Format.fprintf Format.str_formatter "@[<hv>%a@]" format_values vl.pelem;
+  Format.fprintf Format.str_formatter "@[<hv>%a@]" format_values vl;
   Format.flush_str_formatter ()
 
-let format_sstring fmt s =
-  Format.fprintf fmt "%s" s.pelem
-
-let rec format_item fmt i =
-  match i.pelem with
-  | Variable (_, { pelem = List { pelem = []; _}; _}) -> ()
-  | Variable (_,
-              { pelem =
-                  List { pelem =
-                           [{ pelem =
-                                List { pelem = []; _}; _}]; _}; _}) -> ()
-  | Variable (i, { pelem = List { pelem = l; _}; _}) ->
+let rec format_item fmt = function
+  | Variable (_, _, List (_,[])) -> ()
+  | Variable (_, _, List (_,[List(_,[])])) -> ()
+  | Variable (_, i, List (_,l)) ->
     if List.exists
-        (fun v ->
-           match v.pelem with
-             List _ | Option (_,{ pelem = _::_; _}) -> true
-           | _ -> false)
+        (function List _ | Option (_,_,_::_) -> true | _ -> false)
         l
-    then Format.fprintf fmt "@[<v>%a: [@;<0 2>@[<v>%a@]@,]@]"
-        format_sstring i format_values l
-    else Format.fprintf fmt "@[<hv>%a: [@;<0 2>@[<hv>%a@]@,]@]"
-        format_sstring i format_values l
-  | Variable (i, ({ pelem = String s ; _} as v))
-    when String.contains s '\n' ->
-    Format.fprintf fmt "@[<hov 0>%a: %a@]" format_sstring i format_value v
-  | Variable (i, v) ->
-    Format.fprintf fmt "@[<hov 2>%a:@ %a@]" format_sstring i format_value v
-  | Section s ->
-    Format.fprintf fmt "@[<v 0>%a %s{@;<0 2>@[<v>%a@]@,}@]"
-      format_sstring s.section_kind
+    then Format.fprintf fmt "@[<v>%s: [@;<0 2>@[<v>%a@]@,]@]"
+        i format_values l
+    else Format.fprintf fmt "@[<hv>%s: [@;<0 2>@[<hv>%a@]@,]@]"
+        i format_values l
+  | Variable (_, i, (String (_,s) as v)) when String.contains s '\n' ->
+    Format.fprintf fmt "@[<hov 0>%s: %a@]" i format_value v
+  | Variable (_, i, v) ->
+    Format.fprintf fmt "@[<hov 2>%s:@ %a@]" i format_value v
+  | Section (_,s) ->
+    Format.fprintf fmt "@[<v 0>%s %s{@;<0 2>@[<v>%a@]@,}@]"
+      s.section_kind
       (match s.section_name with
-       | Some s -> Printf.sprintf "\"%s\" " (escape_string s.pelem)
+       | Some s -> Printf.sprintf "\"%s\" " (escape_string s)
        | None -> "")
-      format_items s.section_items.pelem
+      format_items s.section_items
 and format_items fmt is =
   Format.pp_open_vbox fmt 0;
   (match is with
@@ -161,55 +139,39 @@ let items l =
 let opamfile f =
   items f.file_contents
 
-let relop_equals r1 r2 = r1.pelem = r2.pelem
-let logop_equals r1 r2 = r1.pelem = r2.pelem
-let pfxop_equals r1 r2 = r1.pelem = r2.pelem
-let env_update_op_equals r1 r2 = r1.pelem = r2.pelem
-
-let rec value_equals v1 v2 =
-  match v1.pelem, v2.pelem with
-  | Bool (b1), Bool (b2) -> b1 = b2
-  | Int (i1), Int (i2) -> i1 = i2
-  | String (s1), String (s2) -> s1 = s2
-  | Relop (r1, va1, vb1), Relop (r2, va2, vb2) ->
-    relop_equals r1  r2 && value_equals va1 va2 && value_equals vb1 vb2
-  | Prefix_relop (r1, v1), Prefix_relop (r2, v2) ->
-    relop_equals r1 r2 && value_equals v1 v2
-  | Logop (l1, va1, vb1), Logop (l2, va2, vb2) ->
-    logop_equals l1 l2 && value_equals va1 va2 && value_equals vb1 vb2
-  | Pfxop (p1, v1), Pfxop (p2, v2) ->
-    pfxop_equals p1 p2 && value_equals v1 v2
-  | Ident (s1), Ident (s2) ->
+let rec value_equals v1 v2 = match v1, v2 with
+  | Bool (_, b1), Bool (_, b2) -> b1 = b2
+  | Int (_, i1), Int (_, i2) -> i1 = i2
+  | String (_, s1), String (_, s2) -> s1 = s2
+  | Relop (_, r1, va1, vb1), Relop (_, r2, va2, vb2) ->
+    r1 = r2 && value_equals va1 va2 && value_equals vb1 vb2
+  | Prefix_relop (_, r1, v1), Prefix_relop (_, r2, v2) ->
+    r1 = r2 && value_equals v1 v2
+  | Logop (_, l1, va1, vb1), Logop (_, l2, va2, vb2) ->
+    l1 = l2 && value_equals va1 va2 && value_equals vb1 vb2
+  | Pfxop (_, p1, v1), Pfxop (_, p2, v2) ->
+    p1 = p2 && value_equals v1 v2
+  | Ident (_, s1), Ident (_, s2) ->
     s1 = s2
-  | List (vl1), List (vl2) ->
-    (try List.for_all2 value_equals vl1.pelem vl2.pelem
-     with Invalid_argument _ -> false)
-  | Group (vl1), Group (vl2) ->
-    (try List.for_all2 value_equals vl1.pelem vl2.pelem
-     with Invalid_argument _ -> false)
-  | Option (v1, vl1), Option (v2, vl2) ->
+  | List (_, vl1), List (_, vl2) ->
+    (try List.for_all2 value_equals vl1 vl2 with Invalid_argument _ -> false)
+  | Group (_, vl1), Group (_, vl2) ->
+    (try List.for_all2 value_equals vl1 vl2 with Invalid_argument _ -> false)
+  | Option (_, v1, vl1), Option (_, v2, vl2) ->
     value_equals v1 v2 &&
-    (try List.for_all2 value_equals vl1.pelem vl2.pelem
-     with Invalid_argument _ -> false)
-  | Env_binding (v1, op1, vx1), Env_binding (v2, op2, vx2) ->
-    env_update_op_equals op1 op2 && value_equals v1 v2 && value_equals vx1 vx2
+    (try List.for_all2 value_equals vl1 vl2 with Invalid_argument _ -> false)
+  | Env_binding (_, v1, op1, vx1), Env_binding (_, v2, op2, vx2) ->
+    op1 = op2 && value_equals v1 v2 && value_equals vx1 vx2
   | _ -> false
 
-let sstring_equals s1 s2 = s1.pelem = s2.pelem
-
-let rec opamfile_item_equals i1 i2 =
-  match i1.pelem , i2.pelem with
-  | Variable (n1, v1), Variable (n2, v2) ->
-    sstring_equals n1 n2 && value_equals v1 v2
-  | Section (s1), Section (s2) ->
-    sstring_equals s1.section_kind s2.section_kind &&
-    (match s1.section_name, s2.section_name with
-     | None, None -> true
-     | Some s1, Some s2 -> sstring_equals s1 s2
-     | _,_ -> false)
-    && (try List.for_all2 opamfile_item_equals
-              s1.section_items.pelem s2.section_items.pelem
-        with Invalid_argument _ -> false)
+let rec opamfile_item_equals i1 i2 = match i1, i2 with
+  | Variable (_, n1, v1), Variable (_, n2, v2) ->
+    n1 = n2 && value_equals v1 v2
+  | Section (_, s1), Section (_, s2) ->
+    s1.section_kind = s2.section_kind &&
+    s1.section_name = s2.section_name &&
+    (try List.for_all2 opamfile_item_equals s1.section_items s2.section_items
+     with Invalid_argument _ -> false)
   | _ -> false
 
 module Normalise = struct
@@ -226,56 +188,46 @@ module Normalise = struct
     Buffer.add_char buf '"';
     Buffer.contents buf
 
-  let rec value v =
-    match v.pelem with
-    | Relop (op,l,r) ->
+  let rec value = function
+    | Relop (_,op,l,r) ->
       String.concat " " [value l; relop op; value r]
-    | Logop (op,l,r) ->
+    | Logop (_,op,l,r) ->
       String.concat " " [value l; logop op; value r]
-    | Pfxop (op,r) ->
+    | Pfxop (_,op,r) ->
       String.concat " " [pfxop op; value r]
-    | Prefix_relop (op,r) ->
+    | Prefix_relop (_,op,r) ->
       String.concat " " [relop op; value r]
-    | Ident s -> s
-    | Int i -> string_of_int i
-    | Bool b -> string_of_bool b
-    | String s -> escape_string s
-    | List l ->
-      Printf.sprintf "[%s]" (String.concat " " (List.map value l.pelem))
-    | Group g ->
-      Printf.sprintf "(%s)" (String.concat " " (List.map value g.pelem))
-    | Option(v,l) ->
-      Printf.sprintf "%s {%s}" (value v)
-        (String.concat " " (List.map value l.pelem))
-    | Env_binding (id,op,v) ->
+    | Ident (_,s) -> s
+    | Int (_,i) -> string_of_int i
+    | Bool (_,b) -> string_of_bool b
+    | String (_,s) -> escape_string s
+    | List (_, l) -> Printf.sprintf "[%s]" (String.concat " " (List.map value l))
+    | Group (_,g) -> Printf.sprintf "(%s)" (String.concat " " (List.map value g))
+    | Option(_,v,l) ->
+      Printf.sprintf "%s {%s}" (value v) (String.concat " " (List.map value l))
+    | Env_binding (_,id,op,v) ->
       String.concat " "
         [value id; env_update_op op; value v]
 
-  let rec item i =
-    match i.pelem with
-    | Variable (_, { pelem = List { pelem = []; _}; _})
-    | Variable (_, { pelem =
-                       List { pelem =
-                                [{ pelem = List { pelem = []; _}; _}]; _}; _})
-      -> ""
-    | Variable (i, { pelem = List { pelem = l; _}; _}) ->
-      Printf.sprintf "%s: [%s]" i.pelem (String.concat " " (List.map value l))
-    | Variable (i, v) -> String.concat ": " [i.pelem; value v]
-    | Section s ->
+  let rec item = function
+    | Variable (_, _, List (_,([]|[List(_,[])]))) -> ""
+    | Variable (_, i, List (_,l)) ->
+      Printf.sprintf "%s: [%s]" i (String.concat " " (List.map value l))
+    | Variable (_, i, v) -> String.concat ": " [i; value v]
+    | Section (_,s) ->
       Printf.sprintf "%s %s{\n%s\n}"
-        s.section_kind.pelem
+        s.section_kind
         (match s.section_name with
-         | Some s -> escape_string s.pelem ^ " "
+         | Some s -> escape_string s ^ " "
          | None -> "")
-        (String.concat "\n" (List.map item s.section_items.pelem))
+        (String.concat "\n" (List.map item s.section_items))
 
-  let item_order a b =
-    match a.pelem ,b.pelem with
+  let item_order a b = match a,b with
     | Section _, Variable _ -> 1
     | Variable _, Section _ -> -1
-    | Variable (i,_), Variable (j,_) -> String.compare i.pelem j.pelem
-    | Section s, Section t ->
-      let r = String.compare s.section_kind.pelem t.section_kind.pelem in
+    | Variable (_,i,_), Variable (_,j,_) -> String.compare i j
+    | Section (_,s), Section (_,t) ->
+      let r = String.compare s.section_kind t.section_kind in
       if r <> 0 then r
       else compare s.section_name t.section_name
 
@@ -301,13 +253,14 @@ module Preserved = struct
         in
         aux [0] txt
       in
-      fun p ->
-        let sli, scol = p.start in
-        let eli, ecol = p.stop in
-        lines_index.(sli - 1) + scol, lines_index.(eli -1) + ecol
+      fun (_file, li, col) -> lines_index.(li - 1) + col
     in
-    let get_substring pos =
-      let start, stop = pos_index pos in
+    let get_substring start_pos rest =
+      let start = pos_index start_pos in
+      let stop = match rest with
+        | (Section (pos,_) | Variable (pos,_,_)) :: _ -> pos_index pos
+        | [] -> String.length txt
+      in
       if stop < start then raise Exit
       else String.sub txt start (stop - start)
     in
@@ -321,51 +274,39 @@ module Preserved = struct
       aux [] l
     in
     let is_variable name = function
-      | { pelem = Variable (name1, _v1); _} -> sstring_equals name name1
+      | Variable (_, name1, _v1) -> name = name1
       | _ -> false
     in
     let is_section kind name = function
-      | { pelem = Section ({section_kind; section_name; _}); _} ->
-        sstring_equals kind section_kind &&
-        (match name, section_name with
-         | None, None -> true
-         | Some s1, Some s2 -> sstring_equals s1 s2
-         | _,_ -> false)
+      | Section (_, {section_kind; section_name; _}) ->
+        kind = section_kind && name = section_name
       | _ -> false
     in
     let rec aux acc f = function
-      | { pos; pelem = Variable ( name, v)} :: r ->
+      | Variable (pos, name, v) :: r ->
         (match list_take (is_variable name) f with
-         | Some {pelem = Variable (_, v1); _}, f when value_equals v v1 ->
-           aux (get_substring pos :: acc) f r
+         | Some (Variable (_, _, v1)), f when value_equals v v1 ->
+           aux (get_substring pos r :: acc) f r
          | Some item, f ->
-           aux (items [item] :: acc) f r
+           aux ((items [item] ^ "\n") :: acc) f r
          | None, f ->
            aux acc f r)
-      | {pos; pelem = Section {section_kind; section_name; _}} as sec :: r ->
+      | Section (pos, {section_kind; section_name; _}) as sec :: r ->
         (match list_take (is_section section_kind section_name) f with
          | Some s, f when opamfile_item_equals sec s ->
-           aux (get_substring pos :: acc) f r
+           aux (get_substring pos r :: acc) f r
          | Some item, f ->
-           aux (items [item] :: acc) f r
+           aux ((items [item] ^ "\n") :: acc) f r
          | None, f -> aux acc f r)
       | [] ->
         let remaining = match f with
-          | [] -> [""]
-          | f -> [items f; ""]
+          | [] -> []
+          | f -> [items f ^ "\n"]
         in
         List.rev_append acc remaining
     in
-    let header =
-      match orig with
-      | [] -> []
-      | h::_ ->
-        let header =
-          get_substring {filename=""; start=(1,0); stop=h.pos.start}
-        in
-        if header = "" then [] else [header]
-    in
-    String.concat "\n" (aux header f orig)
+    let header = [get_substring ("",1,0) orig] in
+    String.concat "" (aux header f orig)
 
   let opamfile ?format_from f =
     let orig_file = match format_from with
@@ -382,4 +323,341 @@ module Preserved = struct
     let orig = OpamParser.string txt orig_file in
     items txt orig.file_contents f.file_contents
 
+end
+
+module FullPos = struct
+
+  open OpamParserTypes.FullPos
+
+  let relop_kind = relop
+  let relop r = relop_kind r.pelem
+  let logop_kind = logop
+  let logop r = logop_kind r.pelem
+  let pfxop_kind = pfxop
+  let pfxop r = pfxop_kind r.pelem
+  let env_update_op_kind = env_update_op
+  let env_update_op r = env_update_op_kind r.pelem
+
+  let rec format_value fmt v =
+    match v.pelem with
+    | Relop (op,l,r) ->
+      Format.fprintf fmt "@[<h>%a %s@ %a@]"
+        format_value l (relop op) format_value r
+    | Logop (op,l,r) ->
+      Format.fprintf fmt "@[<hv>%a %s@ %a@]"
+        format_value l (logop op) format_value r
+    | Pfxop (op,r) ->
+      Format.fprintf fmt "@[<h>%s%a@]" (pfxop op) format_value r
+    | Prefix_relop (op,r) ->
+      Format.fprintf fmt "@[<h>%s@ %a@]"
+        (relop op) format_value r
+    | Ident s -> Format.fprintf fmt "%s" s
+    | Int i -> Format.fprintf fmt "%d" i
+    | Bool b -> Format.fprintf fmt "%b" b
+    | String s ->
+      if String.contains s '\n'
+      then Format.fprintf fmt "\"\"\"%s%s\"\"\""
+          (if s.[0] = '\n' then "" else "\\\n")
+          (escape_string ~triple:true s)
+      else Format.fprintf fmt "\"%s\"" (escape_string s)
+    | List l ->
+      Format.fprintf fmt "@[<hv>[@;<0 2>@[<hv>%a@]@,]@]" format_values l.pelem
+    | Group g -> Format.fprintf fmt "@[<hv>(%a)@]" format_values g.pelem
+    | Option (v,l) ->
+      Format.fprintf fmt "@[<hov 2>%a@ {@[<hv>%a@]}@]"
+        format_value v format_values l.pelem
+    | Env_binding (id,op,v) ->
+      Format.fprintf fmt "@[<h>%a %s@ %a@]"
+        format_value id (env_update_op op) format_value v
+
+  and format_values fmt = function
+    | [] -> ()
+    | [v] -> format_value fmt v
+    | v::r ->
+      format_value fmt v;
+      Format.pp_print_space fmt ();
+      format_values fmt r
+
+  let value v =
+    format_value Format.str_formatter v; Format.flush_str_formatter ()
+
+  let value_list vl =
+    Format.fprintf Format.str_formatter "@[<hv>%a@]" format_values vl.pelem;
+    Format.flush_str_formatter ()
+
+  let format_sstring fmt s =
+    Format.fprintf fmt "%s" s.pelem
+
+  let rec format_item fmt i =
+    match i.pelem with
+    | Variable (_, { pelem = List { pelem = []; _}; _}) -> ()
+    | Variable (_,
+                { pelem =
+                    List { pelem =
+                             [{ pelem =
+                                  List { pelem = []; _}; _}]; _}; _}) -> ()
+    | Variable (i, { pelem = List { pelem = l; _}; _}) ->
+      if List.exists
+          (fun v ->
+             match v.pelem with
+               List _ | Option (_,{ pelem = _::_; _}) -> true
+             | _ -> false)
+          l
+      then Format.fprintf fmt "@[<v>%a: [@;<0 2>@[<v>%a@]@,]@]"
+          format_sstring i format_values l
+      else Format.fprintf fmt "@[<hv>%a: [@;<0 2>@[<hv>%a@]@,]@]"
+          format_sstring i format_values l
+    | Variable (i, ({ pelem = String s ; _} as v))
+      when String.contains s '\n' ->
+      Format.fprintf fmt "@[<hov 0>%a: %a@]" format_sstring i format_value v
+    | Variable (i, v) ->
+      Format.fprintf fmt "@[<hov 2>%a:@ %a@]" format_sstring i format_value v
+    | Section s ->
+      Format.fprintf fmt "@[<v 0>%a %s{@;<0 2>@[<v>%a@]@,}@]"
+        format_sstring s.section_kind
+        (match s.section_name with
+         | Some s -> Printf.sprintf "\"%s\" " (escape_string s.pelem)
+         | None -> "")
+        format_items s.section_items.pelem
+  and format_items fmt is =
+    Format.pp_open_vbox fmt 0;
+    (match is with
+     | [] -> ()
+     | i::r ->
+       format_item fmt i;
+       List.iter (fun i -> Format.pp_print_cut fmt (); format_item fmt i) r);
+    Format.pp_close_box fmt ()
+
+  let format_opamfile fmt f =
+    format_items fmt f.file_contents;
+    Format.pp_print_newline fmt ()
+
+  let items l =
+    format_items Format.str_formatter l; Format.flush_str_formatter ()
+
+  let opamfile f =
+    items f.file_contents
+
+  let relop_equals r1 r2 = r1.pelem = r2.pelem
+  let logop_equals r1 r2 = r1.pelem = r2.pelem
+  let pfxop_equals r1 r2 = r1.pelem = r2.pelem
+  let env_update_op_equals r1 r2 = r1.pelem = r2.pelem
+
+  let rec value_equals v1 v2 =
+    match v1.pelem, v2.pelem with
+    | Bool (b1), Bool (b2) -> b1 = b2
+    | Int (i1), Int (i2) -> i1 = i2
+    | String (s1), String (s2) -> s1 = s2
+    | Relop (r1, va1, vb1), Relop (r2, va2, vb2) ->
+      relop_equals r1  r2 && value_equals va1 va2 && value_equals vb1 vb2
+    | Prefix_relop (r1, v1), Prefix_relop (r2, v2) ->
+      relop_equals r1 r2 && value_equals v1 v2
+    | Logop (l1, va1, vb1), Logop (l2, va2, vb2) ->
+      logop_equals l1 l2 && value_equals va1 va2 && value_equals vb1 vb2
+    | Pfxop (p1, v1), Pfxop (p2, v2) ->
+      pfxop_equals p1 p2 && value_equals v1 v2
+    | Ident (s1), Ident (s2) ->
+      s1 = s2
+    | List (vl1), List (vl2) ->
+      (try List.for_all2 value_equals vl1.pelem vl2.pelem
+       with Invalid_argument _ -> false)
+    | Group (vl1), Group (vl2) ->
+      (try List.for_all2 value_equals vl1.pelem vl2.pelem
+       with Invalid_argument _ -> false)
+    | Option (v1, vl1), Option (v2, vl2) ->
+      value_equals v1 v2 &&
+      (try List.for_all2 value_equals vl1.pelem vl2.pelem
+       with Invalid_argument _ -> false)
+    | Env_binding (v1, op1, vx1), Env_binding (v2, op2, vx2) ->
+      env_update_op_equals op1 op2 && value_equals v1 v2 && value_equals vx1 vx2
+    | _ -> false
+
+  let sstring_equals s1 s2 = s1.pelem = s2.pelem
+
+  let rec opamfile_item_equals i1 i2 =
+    match i1.pelem , i2.pelem with
+    | Variable (n1, v1), Variable (n2, v2) ->
+      sstring_equals n1 n2 && value_equals v1 v2
+    | Section (s1), Section (s2) ->
+      sstring_equals s1.section_kind s2.section_kind &&
+      (match s1.section_name, s2.section_name with
+       | None, None -> true
+       | Some s1, Some s2 -> sstring_equals s1 s2
+       | _,_ -> false)
+      && (try List.for_all2 opamfile_item_equals
+                s1.section_items.pelem s2.section_items.pelem
+          with Invalid_argument _ -> false)
+    | _ -> false
+
+  module Normalise = struct
+    let escape_string s =
+      let len = String.length s in
+      let buf = Buffer.create (len * 2) in
+      Buffer.add_char buf '"';
+      for i = 0 to len -1 do
+        match s.[i] with
+        | '\\' | '"' as c -> Buffer.add_char buf '\\'; Buffer.add_char buf c
+        | '\n' -> Buffer.add_string buf "\\n"
+        | c -> Buffer.add_char buf c
+      done;
+      Buffer.add_char buf '"';
+      Buffer.contents buf
+
+    let rec value v =
+      match v.pelem with
+      | Relop (op,l,r) ->
+        String.concat " " [value l; relop op; value r]
+      | Logop (op,l,r) ->
+        String.concat " " [value l; logop op; value r]
+      | Pfxop (op,r) ->
+        String.concat " " [pfxop op; value r]
+      | Prefix_relop (op,r) ->
+        String.concat " " [relop op; value r]
+      | Ident s -> s
+      | Int i -> string_of_int i
+      | Bool b -> string_of_bool b
+      | String s -> escape_string s
+      | List l ->
+        Printf.sprintf "[%s]" (String.concat " " (List.map value l.pelem))
+      | Group g ->
+        Printf.sprintf "(%s)" (String.concat " " (List.map value g.pelem))
+      | Option(v,l) ->
+        Printf.sprintf "%s {%s}" (value v)
+          (String.concat " " (List.map value l.pelem))
+      | Env_binding (id,op,v) ->
+        String.concat " "
+          [value id; env_update_op op; value v]
+
+    let rec item i =
+      match i.pelem with
+      | Variable (_, { pelem = List { pelem = []; _}; _})
+      | Variable (_, { pelem =
+                         List { pelem =
+                                  [{ pelem = List { pelem = []; _}; _}]; _}; _})
+        -> ""
+      | Variable (i, { pelem = List { pelem = l; _}; _}) ->
+        Printf.sprintf "%s: [%s]" i.pelem (String.concat " " (List.map value l))
+      | Variable (i, v) -> String.concat ": " [i.pelem; value v]
+      | Section s ->
+        Printf.sprintf "%s %s{\n%s\n}"
+          s.section_kind.pelem
+          (match s.section_name with
+           | Some s -> escape_string s.pelem ^ " "
+           | None -> "")
+          (String.concat "\n" (List.map item s.section_items.pelem))
+
+    let item_order a b =
+      match a.pelem ,b.pelem with
+      | Section _, Variable _ -> 1
+      | Variable _, Section _ -> -1
+      | Variable (i,_), Variable (j,_) -> String.compare i.pelem j.pelem
+      | Section s, Section t ->
+        let r = String.compare s.section_kind.pelem t.section_kind.pelem in
+        if r <> 0 then r
+        else compare s.section_name t.section_name
+
+    let items its =
+      let its = List.sort item_order its in
+      String.concat "\n" (List.map item its) ^ "\n"
+
+    let opamfile f = items f.file_contents
+  end
+
+  module Preserved = struct
+    let items txt orig f =
+      let pos_index =
+        let lines_index =
+          let rec aux acc s =
+            let until =
+              try Some (String.index_from s (List.hd acc) '\n')
+              with Not_found -> None
+            in
+            match until with
+            | Some until -> aux (until+1 :: acc) s
+            | None -> Array.of_list (List.rev acc)
+          in
+          aux [0] txt
+        in
+        fun p ->
+          let sli, scol = p.start in
+          let eli, ecol = p.stop in
+          lines_index.(sli - 1) + scol, lines_index.(eli -1) + ecol
+      in
+      let get_substring pos =
+        let start, stop = pos_index pos in
+        if stop < start then raise Exit
+        else String.sub txt start (stop - start)
+      in
+      let list_take f l =
+        let rec aux acc = function
+          | [] -> None, List.rev acc
+          | x::r ->
+            if f x then Some x, List.rev_append acc r
+            else aux (x::acc) r
+        in
+        aux [] l
+      in
+      let is_variable name = function
+        | { pelem = Variable (name1, _v1); _} -> sstring_equals name name1
+        | _ -> false
+      in
+      let is_section kind name = function
+        | { pelem = Section ({section_kind; section_name; _}); _} ->
+          sstring_equals kind section_kind &&
+          (match name, section_name with
+           | None, None -> true
+           | Some s1, Some s2 -> sstring_equals s1 s2
+           | _,_ -> false)
+        | _ -> false
+      in
+      let rec aux acc f = function
+        | { pos; pelem = Variable ( name, v)} :: r ->
+          (match list_take (is_variable name) f with
+           | Some {pelem = Variable (_, v1); _}, f when value_equals v v1 ->
+             aux (get_substring pos :: acc) f r
+           | Some item, f ->
+             aux (items [item] :: acc) f r
+           | None, f ->
+             aux acc f r)
+        | {pos; pelem = Section {section_kind; section_name; _}} as sec :: r ->
+          (match list_take (is_section section_kind section_name) f with
+           | Some s, f when opamfile_item_equals sec s ->
+             aux (get_substring pos :: acc) f r
+           | Some item, f ->
+             aux (items [item] :: acc) f r
+           | None, f -> aux acc f r)
+        | [] ->
+          let remaining = match f with
+            | [] -> [""]
+            | f -> [items f; ""]
+          in
+          List.rev_append acc remaining
+      in
+      let header =
+        match orig with
+        | [] -> []
+        | h::_ ->
+          let header =
+            get_substring {filename=""; start=(1,0); stop=h.pos.start}
+          in
+          if header = "" then [] else [header]
+      in
+      String.concat "\n" (aux header f orig)
+
+    let opamfile ?format_from f =
+      let orig_file = match format_from with
+        | Some name -> name
+        | None -> f.file_name
+      in
+      let txt =
+        let b = Buffer.create 4096 in
+        let ic = open_in orig_file in
+        try while true do Buffer.add_channel b ic 4096 done; assert false with
+        | End_of_file -> close_in ic; Buffer.contents b
+        | e -> close_in ic; raise e
+      in
+      let orig = OpamParser.FullPos.string txt orig_file in
+      items txt orig.file_contents f.file_contents
+
+  end
 end

--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -320,7 +320,7 @@ module Preserved = struct
       | End_of_file -> close_in ic; Buffer.contents b
       | e -> close_in ic; raise e
     in
-    let orig = OpamParser.string txt orig_file in
+    let[@ocaml.warning "-3"] orig = OpamParser.string txt orig_file in
     items txt orig.file_contents f.file_contents
 
 end

--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -11,7 +11,7 @@
 
 open OpamParserTypes
 
-let relop = function
+let relop_kind = function
   | `Eq  -> "="
   | `Neq -> "!="
   | `Geq -> ">="
@@ -20,21 +20,29 @@ let relop = function
   | `Lt  -> "<"
   | `Sem -> "~"
 
-let logop = function
+let relop r = relop_kind r.pelem
+
+let logop_kind = function
   | `And -> "&"
   | `Or -> "|"
 
-let pfxop = function
+let logop r = logop_kind r.pelem
+
+let pfxop_kind = function
   | `Not -> "!"
   | `Defined -> "?"
 
-let env_update_op = function
+let pfxop r = pfxop_kind r.pelem
+
+let env_update_op_kind = function
   | Eq -> "="
   | PlusEq -> "+="
   | EqPlus -> "=+"
   | EqPlusEq -> "=+="
   | ColonEq -> ":="
   | EqColon -> "=:"
+
+let env_update_op r = env_update_op_kind r.pelem
 
 let escape_string ?(triple=false) s =
   let len = String.length s in
@@ -53,33 +61,35 @@ let escape_string ?(triple=false) s =
   done;
   Buffer.contents buf
 
-let rec format_value fmt = function
-  | Relop (_,op,l,r) ->
+let rec format_value fmt v =
+  match v.pelem with
+  | Relop (op,l,r) ->
     Format.fprintf fmt "@[<h>%a %s@ %a@]"
       format_value l (relop op) format_value r
-  | Logop (_,op,l,r) ->
+  | Logop (op,l,r) ->
     Format.fprintf fmt "@[<hv>%a %s@ %a@]"
       format_value l (logop op) format_value r
-  | Pfxop (_,op,r) ->
+  | Pfxop (op,r) ->
     Format.fprintf fmt "@[<h>%s%a@]" (pfxop op) format_value r
-  | Prefix_relop (_,op,r) ->
+  | Prefix_relop (op,r) ->
     Format.fprintf fmt "@[<h>%s@ %a@]"
       (relop op) format_value r
-  | Ident (_,s)     -> Format.fprintf fmt "%s" s
-  | Int (_,i)       -> Format.fprintf fmt "%d" i
-  | Bool (_,b)      -> Format.fprintf fmt "%b" b
-  | String (_,s)    ->
+  | Ident s -> Format.fprintf fmt "%s" s
+  | Int i -> Format.fprintf fmt "%d" i
+  | Bool b -> Format.fprintf fmt "%b" b
+  | String s ->
     if String.contains s '\n'
     then Format.fprintf fmt "\"\"\"%s%s\"\"\""
         (if s.[0] = '\n' then "" else "\\\n")
         (escape_string ~triple:true s)
     else Format.fprintf fmt "\"%s\"" (escape_string s)
-  | List (_, l) ->
-    Format.fprintf fmt "@[<hv>[@;<0 2>@[<hv>%a@]@,]@]" format_values l
-  | Group (_,g)     -> Format.fprintf fmt "@[<hv>(%a)@]" format_values g
-  | Option(_,v,l)   -> Format.fprintf fmt "@[<hov 2>%a@ {@[<hv>%a@]}@]"
-                         format_value v format_values l
-  | Env_binding (_,id,op,v) ->
+  | List l ->
+    Format.fprintf fmt "@[<hv>[@;<0 2>@[<hv>%a@]@,]@]" format_values l.pelem
+  | Group g -> Format.fprintf fmt "@[<hv>(%a)@]" format_values g.pelem
+  | Option (v,l) ->
+    Format.fprintf fmt "@[<hov 2>%a@ {@[<hv>%a@]}@]"
+      format_value v format_values l.pelem
+  | Env_binding (id,op,v) ->
     Format.fprintf fmt "@[<h>%a %s@ %a@]"
       format_value id (env_update_op op) format_value v
 
@@ -95,31 +105,43 @@ let value v =
   format_value Format.str_formatter v; Format.flush_str_formatter ()
 
 let value_list vl =
-  Format.fprintf Format.str_formatter "@[<hv>%a@]" format_values vl;
+  Format.fprintf Format.str_formatter "@[<hv>%a@]" format_values vl.pelem;
   Format.flush_str_formatter ()
 
-let rec format_item fmt = function
-  | Variable (_, _, List (_,[])) -> ()
-  | Variable (_, _, List (_,[List(_,[])])) -> ()
-  | Variable (_, i, List (_,l)) ->
+let format_sstring fmt s =
+  Format.fprintf fmt "%s" s.pelem
+
+let rec format_item fmt i =
+  match i.pelem with
+  | Variable (_, { pelem = List { pelem = []; _}; _}) -> ()
+  | Variable (_,
+              { pelem =
+                  List { pelem =
+                           [{ pelem =
+                                List { pelem = []; _}; _}]; _}; _}) -> ()
+  | Variable (i, { pelem = List { pelem = l; _}; _}) ->
     if List.exists
-        (function List _ | Option (_,_,_::_) -> true | _ -> false)
+        (fun v ->
+           match v.pelem with
+             List _ | Option (_,{ pelem = _::_; _}) -> true
+           | _ -> false)
         l
-    then Format.fprintf fmt "@[<v>%s: [@;<0 2>@[<v>%a@]@,]@]"
-        i format_values l
-    else Format.fprintf fmt "@[<hv>%s: [@;<0 2>@[<hv>%a@]@,]@]"
-        i format_values l
-  | Variable (_, i, (String (_,s) as v)) when String.contains s '\n' ->
-    Format.fprintf fmt "@[<hov 0>%s: %a@]" i format_value v
-  | Variable (_, i, v) ->
-    Format.fprintf fmt "@[<hov 2>%s:@ %a@]" i format_value v
-  | Section (_,s) ->
-    Format.fprintf fmt "@[<v 0>%s %s{@;<0 2>@[<v>%a@]@,}@]"
-      s.section_kind
+    then Format.fprintf fmt "@[<v>%a: [@;<0 2>@[<v>%a@]@,]@]"
+        format_sstring i format_values l
+    else Format.fprintf fmt "@[<hv>%a: [@;<0 2>@[<hv>%a@]@,]@]"
+        format_sstring i format_values l
+  | Variable (i, ({ pelem = String s ; _} as v))
+    when String.contains s '\n' ->
+    Format.fprintf fmt "@[<hov 0>%a: %a@]" format_sstring i format_value v
+  | Variable (i, v) ->
+    Format.fprintf fmt "@[<hov 2>%a:@ %a@]" format_sstring i format_value v
+  | Section s ->
+    Format.fprintf fmt "@[<v 0>%a %s{@;<0 2>@[<v>%a@]@,}@]"
+      format_sstring s.section_kind
       (match s.section_name with
-       | Some s -> Printf.sprintf "\"%s\" " (escape_string s)
+       | Some s -> Printf.sprintf "\"%s\" " (escape_string s.pelem)
        | None -> "")
-      format_items s.section_items
+      format_items s.section_items.pelem
 and format_items fmt is =
   Format.pp_open_vbox fmt 0;
   (match is with
@@ -139,39 +161,55 @@ let items l =
 let opamfile f =
   items f.file_contents
 
-let rec value_equals v1 v2 = match v1, v2 with
-  | Bool (_, b1), Bool (_, b2) -> b1 = b2
-  | Int (_, i1), Int (_, i2) -> i1 = i2
-  | String (_, s1), String (_, s2) -> s1 = s2
-  | Relop (_, r1, va1, vb1), Relop (_, r2, va2, vb2) ->
-    r1 = r2 && value_equals va1 va2 && value_equals vb1 vb2
-  | Prefix_relop (_, r1, v1), Prefix_relop (_, r2, v2) ->
-    r1 = r2 && value_equals v1 v2
-  | Logop (_, l1, va1, vb1), Logop (_, l2, va2, vb2) ->
-    l1 = l2 && value_equals va1 va2 && value_equals vb1 vb2
-  | Pfxop (_, p1, v1), Pfxop (_, p2, v2) ->
-    p1 = p2 && value_equals v1 v2
-  | Ident (_, s1), Ident (_, s2) ->
+let relop_equals r1 r2 = r1.pelem = r2.pelem
+let logop_equals r1 r2 = r1.pelem = r2.pelem
+let pfxop_equals r1 r2 = r1.pelem = r2.pelem
+let env_update_op_equals r1 r2 = r1.pelem = r2.pelem
+
+let rec value_equals v1 v2 =
+  match v1.pelem, v2.pelem with
+  | Bool (b1), Bool (b2) -> b1 = b2
+  | Int (i1), Int (i2) -> i1 = i2
+  | String (s1), String (s2) -> s1 = s2
+  | Relop (r1, va1, vb1), Relop (r2, va2, vb2) ->
+    relop_equals r1  r2 && value_equals va1 va2 && value_equals vb1 vb2
+  | Prefix_relop (r1, v1), Prefix_relop (r2, v2) ->
+    relop_equals r1 r2 && value_equals v1 v2
+  | Logop (l1, va1, vb1), Logop (l2, va2, vb2) ->
+    logop_equals l1 l2 && value_equals va1 va2 && value_equals vb1 vb2
+  | Pfxop (p1, v1), Pfxop (p2, v2) ->
+    pfxop_equals p1 p2 && value_equals v1 v2
+  | Ident (s1), Ident (s2) ->
     s1 = s2
-  | List (_, vl1), List (_, vl2) ->
-    (try List.for_all2 value_equals vl1 vl2 with Invalid_argument _ -> false)
-  | Group (_, vl1), Group (_, vl2) ->
-    (try List.for_all2 value_equals vl1 vl2 with Invalid_argument _ -> false)
-  | Option (_, v1, vl1), Option (_, v2, vl2) ->
+  | List (vl1), List (vl2) ->
+    (try List.for_all2 value_equals vl1.pelem vl2.pelem
+     with Invalid_argument _ -> false)
+  | Group (vl1), Group (vl2) ->
+    (try List.for_all2 value_equals vl1.pelem vl2.pelem
+     with Invalid_argument _ -> false)
+  | Option (v1, vl1), Option (v2, vl2) ->
     value_equals v1 v2 &&
-    (try List.for_all2 value_equals vl1 vl2 with Invalid_argument _ -> false)
-  | Env_binding (_, v1, op1, vx1), Env_binding (_, v2, op2, vx2) ->
-    op1 = op2 && value_equals v1 v2 && value_equals vx1 vx2
+    (try List.for_all2 value_equals vl1.pelem vl2.pelem
+     with Invalid_argument _ -> false)
+  | Env_binding (v1, op1, vx1), Env_binding (v2, op2, vx2) ->
+    env_update_op_equals op1 op2 && value_equals v1 v2 && value_equals vx1 vx2
   | _ -> false
 
-let rec opamfile_item_equals i1 i2 = match i1, i2 with
-  | Variable (_, n1, v1), Variable (_, n2, v2) ->
-    n1 = n2 && value_equals v1 v2
-  | Section (_, s1), Section (_, s2) ->
-    s1.section_kind = s2.section_kind &&
-    s1.section_name = s2.section_name &&
-    (try List.for_all2 opamfile_item_equals s1.section_items s2.section_items
-     with Invalid_argument _ -> false)
+let sstring_equals s1 s2 = s1.pelem = s2.pelem
+
+let rec opamfile_item_equals i1 i2 =
+  match i1.pelem , i2.pelem with
+  | Variable (n1, v1), Variable (n2, v2) ->
+    sstring_equals n1 n2 && value_equals v1 v2
+  | Section (s1), Section (s2) ->
+    sstring_equals s1.section_kind s2.section_kind &&
+    (match s1.section_name, s2.section_name with
+     | None, None -> true
+     | Some s1, Some s2 -> sstring_equals s1 s2
+     | _,_ -> false)
+    && (try List.for_all2 opamfile_item_equals
+              s1.section_items.pelem s2.section_items.pelem
+        with Invalid_argument _ -> false)
   | _ -> false
 
 module Normalise = struct
@@ -188,46 +226,56 @@ module Normalise = struct
     Buffer.add_char buf '"';
     Buffer.contents buf
 
-  let rec value = function
-    | Relop (_,op,l,r) ->
+  let rec value v =
+    match v.pelem with
+    | Relop (op,l,r) ->
       String.concat " " [value l; relop op; value r]
-    | Logop (_,op,l,r) ->
+    | Logop (op,l,r) ->
       String.concat " " [value l; logop op; value r]
-    | Pfxop (_,op,r) ->
+    | Pfxop (op,r) ->
       String.concat " " [pfxop op; value r]
-    | Prefix_relop (_,op,r) ->
+    | Prefix_relop (op,r) ->
       String.concat " " [relop op; value r]
-    | Ident (_,s) -> s
-    | Int (_,i) -> string_of_int i
-    | Bool (_,b) -> string_of_bool b
-    | String (_,s) -> escape_string s
-    | List (_, l) -> Printf.sprintf "[%s]" (String.concat " " (List.map value l))
-    | Group (_,g) -> Printf.sprintf "(%s)" (String.concat " " (List.map value g))
-    | Option(_,v,l) ->
-      Printf.sprintf "%s {%s}" (value v) (String.concat " " (List.map value l))
-    | Env_binding (_,id,op,v) ->
+    | Ident s -> s
+    | Int i -> string_of_int i
+    | Bool b -> string_of_bool b
+    | String s -> escape_string s
+    | List l ->
+      Printf.sprintf "[%s]" (String.concat " " (List.map value l.pelem))
+    | Group g ->
+      Printf.sprintf "(%s)" (String.concat " " (List.map value g.pelem))
+    | Option(v,l) ->
+      Printf.sprintf "%s {%s}" (value v)
+        (String.concat " " (List.map value l.pelem))
+    | Env_binding (id,op,v) ->
       String.concat " "
         [value id; env_update_op op; value v]
 
-  let rec item = function
-    | Variable (_, _, List (_,([]|[List(_,[])]))) -> ""
-    | Variable (_, i, List (_,l)) ->
-      Printf.sprintf "%s: [%s]" i (String.concat " " (List.map value l))
-    | Variable (_, i, v) -> String.concat ": " [i; value v]
-    | Section (_,s) ->
+  let rec item i =
+    match i.pelem with
+    | Variable (_, { pelem = List { pelem = []; _}; _})
+    | Variable (_, { pelem =
+                       List { pelem =
+                                [{ pelem = List { pelem = []; _}; _}]; _}; _})
+      -> ""
+    | Variable (i, { pelem = List { pelem = l; _}; _}) ->
+      Printf.sprintf "%s: [%s]" i.pelem (String.concat " " (List.map value l))
+    | Variable (i, v) -> String.concat ": " [i.pelem; value v]
+    | Section s ->
       Printf.sprintf "%s %s{\n%s\n}"
-        s.section_kind
+        s.section_kind.pelem
         (match s.section_name with
-         | Some s -> escape_string s ^ " "
+         | Some s -> escape_string s.pelem ^ " "
          | None -> "")
-        (String.concat "\n" (List.map item s.section_items))
+        (String.concat "\n" (List.map item s.section_items.pelem))
 
-  let item_order a b = match a,b with
+  let item_order a b =
+    match a.pelem ,b.pelem with
     | Section _, Variable _ -> 1
     | Variable _, Section _ -> -1
-    | Variable (_,i,_), Variable (_,j,_) -> String.compare i j
-    | Section (_,s), Section (_,t) ->
-      let r = String.compare s.section_kind t.section_kind in
+    | Variable (i,_), Variable (j,_) -> String.compare i.pelem j.pelem
+    | Section s, Section t ->
+      let r = String.compare s.section_kind.pelem t.section_kind.pelem in
       if r <> 0 then r
       else compare s.section_name t.section_name
 
@@ -253,14 +301,13 @@ module Preserved = struct
         in
         aux [0] txt
       in
-      fun (_file, li, col) -> lines_index.(li - 1) + col
+      fun p ->
+        let sli, scol = p.start in
+        let eli, ecol = p.stop in
+        lines_index.(sli - 1) + scol, lines_index.(eli -1) + ecol
     in
-    let get_substring start_pos rest =
-      let start = pos_index start_pos in
-      let stop = match rest with
-        | (Section (pos,_) | Variable (pos,_,_)) :: _ -> pos_index pos
-        | [] -> String.length txt
-      in
+    let get_substring pos =
+      let start, stop = pos_index pos in
       if stop < start then raise Exit
       else String.sub txt start (stop - start)
     in
@@ -274,39 +321,51 @@ module Preserved = struct
       aux [] l
     in
     let is_variable name = function
-      | Variable (_, name1, _v1) -> name = name1
+      | { pelem = Variable (name1, _v1); _} -> sstring_equals name name1
       | _ -> false
     in
     let is_section kind name = function
-      | Section (_, {section_kind; section_name; _}) ->
-        kind = section_kind && name = section_name
+      | { pelem = Section ({section_kind; section_name; _}); _} ->
+        sstring_equals kind section_kind &&
+        (match name, section_name with
+         | None, None -> true
+         | Some s1, Some s2 -> sstring_equals s1 s2
+         | _,_ -> false)
       | _ -> false
     in
     let rec aux acc f = function
-      | Variable (pos, name, v) :: r ->
+      | { pos; pelem = Variable ( name, v)} :: r ->
         (match list_take (is_variable name) f with
-         | Some (Variable (_, _, v1)), f when value_equals v v1 ->
-           aux (get_substring pos r :: acc) f r
+         | Some {pelem = Variable (_, v1); _}, f when value_equals v v1 ->
+           aux (get_substring pos :: acc) f r
          | Some item, f ->
-           aux ((items [item] ^ "\n") :: acc) f r
+           aux (items [item] :: acc) f r
          | None, f ->
            aux acc f r)
-      | Section (pos, {section_kind; section_name; _}) as sec :: r ->
+      | {pos; pelem = Section {section_kind; section_name; _}} as sec :: r ->
         (match list_take (is_section section_kind section_name) f with
          | Some s, f when opamfile_item_equals sec s ->
-           aux (get_substring pos r :: acc) f r
+           aux (get_substring pos :: acc) f r
          | Some item, f ->
-           aux ((items [item] ^ "\n") :: acc) f r
+           aux (items [item] :: acc) f r
          | None, f -> aux acc f r)
       | [] ->
         let remaining = match f with
-          | [] -> []
-          | f -> [items f ^ "\n"]
+          | [] -> [""]
+          | f -> [items f; ""]
         in
         List.rev_append acc remaining
     in
-    let header = [get_substring ("",1,0) orig] in
-    String.concat "" (aux header f orig)
+    let header =
+      match orig with
+      | [] -> []
+      | h::_ ->
+        let header =
+          get_substring {filename=""; start=(1,0); stop=h.pos.start}
+        in
+        if header = "" then [] else [header]
+    in
+    String.concat "\n" (aux header f orig)
 
   let opamfile ?format_from f =
     let orig_file = match format_from with

--- a/src/opamPrinter.mli
+++ b/src/opamPrinter.mli
@@ -11,71 +11,148 @@
 
 (** Functions for converting parsed opam files back to strings *)
 
-(** {2 Printers for the [value] and [opamfile] formats} *)
+
+(** [OpamPrinter] transitional module with full position types *)
+module FullPos : sig
+
+  open OpamParserTypes.FullPos
+
+  (** {2 Printers for the [value] and [opamfile] formats} *)
+
+  val relop_kind: [< relop_kind ] -> string
+  (** Converts {!OpamParserTypes.FullPos.relop_kind} to its string representation
+      ([=], [!=], ..., [~]). *)
+
+  val logop_kind: [< logop_kind ] -> string
+  (** Converts {!OpamParserTypes.FullPos.logop_kind} to its string representation
+      ([&] and [|]). *)
+
+  val pfxop_kind: [< pfxop_kind ] -> string
+  (** Converts {!OpamParserTypes.FullPos.logop_kind} to its string representation
+      ([&] and [|]). *)
+
+  val env_update_op_kind: env_update_op_kind -> string
+  (** Converts {!OpamParserTypes.FullPos.env_update_op_kind} to its string representation
+      ([=], [+=], ..., [=:]). *)
+
+
+  val relop: rel_op -> string
+  (** Converts {!OpamParserTypes.FullPos.rel_op} to its string representation
+      ([=], [!=], ..., [~]). *)
+
+  val logop: log_op -> string
+  (** Converts {!OpamParserTypes.FullPos.log_op} to its string representation
+      ([&] and [|]). *)
+
+  val pfxop: pfx_op -> string
+  (** Converts {!OpamParserTypes.FullPos.pfx_op} to its string representation
+      ([!] and [?]). *)
+
+  val env_update_op: env_update_op -> string
+  (** Converts {!OpamParserTypes.FullPos.env_update_op} to its string representation
+      ([=], [+=], ..., [=:]). *)
+
+
+  val value : value -> string
+  (** Converts {!value} to a string {b always using LF-encoding of newlines}. *)
+
+  val value_list: value list with_pos -> string
+  (** Converts a list of {!value}s to a string {b always using LF-encoding of
+      newlines}. *)
+
+  val items: opamfile_item list -> string
+
+  val opamfile: opamfile -> string
+  (** Converts an {!opamfile} to a string. *)
+
+  val format_opamfile: Format.formatter -> opamfile -> unit
+  (** Writes an {!opamfile} to a [Format.formatter]. The function ensures that all
+      newlines are sent using [Format]'s break instructions (and so ultimately are
+      processed with the [out_newline] function of the formatter) but it is the
+      responsibility of the caller to ensure that the formatter is configured for
+      the required output, if necessary. *)
+
+  (** {2 Normalised output for opam syntax files} *)
+
+  (** opam normalised file format, for signatures.
+
+      - each top-level field on a single line
+      - newlines are LF-encoded (including on Windows)
+      - file ends with a newline
+      - spaces only after [fieldname:], between elements in lists, before braced
+          options, between operators and their operands
+      - fields are sorted lexicographically by field name
+          (using [String.compare])
+      - newlines in strings turned to ['\n'], backslashes and double quotes
+          escaped
+      - no comments (they don't appear in the internal file format anyway)
+      - fields containing an empty list, or a singleton list containing an empty
+          list, are not printed at all
+  *)
+  module Normalise : sig
+    val escape_string : string -> string
+    val value : value -> string
+    val item : opamfile_item -> string
+    val item_order : opamfile_item -> opamfile_item -> int
+    val items : opamfile_item list -> string
+    val opamfile : opamfile -> string
+  end
+
+  (** {2 Format-preserving reprinter} *)
+
+  module Preserved : sig
+
+    val items: string -> opamfile_item list -> opamfile_item list -> string
+    (** [items str orig_its its] converts [its] to string, while attempting to
+        preserve the layout and comments of the original [str] for unmodified
+        elements. The function assumes that [str] parses to the items
+        [orig_its]. *)
+
+    val opamfile: ?format_from:file_name -> opamfile -> string
+    (** [opamfile f] converts [f] to string, respecting the layout and comments in
+        the corresponding on-disk file for unmodified items. [format_from] can be
+        specified instead of using the filename specified in [f]. *)
+  end
+
+  (** {2 Random utility functions} *)
+
+  val value_equals: value -> value -> bool
+  (** Compares structurally, without considering file positions *)
+
+  val opamfile_item_equals: opamfile_item -> opamfile_item -> bool
+  (** Compares structurally, without considering file positions *)
+
+end
 
 open OpamParserTypes
 
 val relop: [< relop ] -> string
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.relop instead."]
-(** Converts {!OpamParserTypes.relop} to its string representation
-    ([=], [!=], ..., [~]). *)
 
 val logop: [< logop ] -> string
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.logop instead."]
-(** Converts {!OpamParserTypes.logop} to its string representation
-    ([&] and [|]). *)
 
 val pfxop: [< pfxop ] -> string
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.pfxop instead."]
-(** Converts {!OpamParserTypes.pfxop} to its string representation
-    ([!] and [?]). *)
 
 val env_update_op: env_update_op -> string
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.env_update_op instead."]
-(** Converts {!OpamParserTypes.env_update_op} to its string representation
-    ([=], [+=], ..., [=:]). *)
 
 val value : value -> string
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.value instead."]
-(** Converts {!value} to a string {b always using LF-encoding of newlines}. *)
 
 val value_list: value list -> string
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.value_list instead."]
-(** Converts a list of {!value}s to a string {b always using LF-encoding of
-    newlines}. *)
 
 val items: opamfile_item list -> string
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.items instead."]
 
 val opamfile: opamfile -> string
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.opamfile instead."]
-(** Converts an {!opamfile} to a string. *)
 
 val format_opamfile: Format.formatter -> opamfile -> unit
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.format_opamfile instead."]
-(** Writes an {!opamfile} to a [Format.formatter]. The function ensures that all
-    newlines are sent using [Format]'s break instructions (and so ultimately are
-    processed with the [out_newline] function of the formatter) but it is the
-    responsibility of the caller to ensure that the formatter is configured for
-    the required output, if necessary. *)
 
-(** {2 Normalised output for opam syntax files} *)
-
-(** opam normalised file format, for signatures.
-
-      - each top-level field on a single line
-      - newlines are LF-encoded (including on Windows)
-      - file ends with a newline
-      - spaces only after [fieldname:], between elements in lists, before braced
-        options, between operators and their operands
-      - fields are sorted lexicographically by field name
-        (using [String.compare])
-      - newlines in strings turned to ['\n'], backslashes and double quotes
-        escaped
-      - no comments (they don't appear in the internal file format anyway)
-      - fields containing an empty list, or a singleton list containing an empty
-        list, are not printed at all
-*)
 module Normalise : sig
   val escape_string : string -> string
   val value : value -> string
@@ -86,71 +163,17 @@ module Normalise : sig
 end
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.Normalise instead."]
 
-(** {2 Format-preserving reprinter} *)
-
 module Preserved : sig
-  (** [items str orig_its its] converts [its] to string, while attempting to
-      preserve the layout and comments of the original [str] for unmodified
-      elements. The function assumes that [str] parses to the items
-      [orig_its]. *)
   val items: string -> opamfile_item list -> opamfile_item list -> string
 
   val opamfile: ?format_from:file_name -> opamfile -> string
-  (** [opamfile f] converts [f] to string, respecting the layout and comments in
-      the corresponding on-disk file for unmodified items. [format_from] can be
-      specified instead of using the filename specified in [f]. *)
 end
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.Preserved instead."]
 
-(** {2 Random utility functions} *)
 
 val value_equals: value -> value -> bool
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.value_equals instead."]
-(** Compares structurally, without considering file positions *)
 
 val opamfile_item_equals: opamfile_item -> opamfile_item -> bool
 [@@ocaml.deprecated "Use OpamPrinter.FullPos.opamfile_item_equals instead."]
-(** Compares structurally, without considering file positions *)
 
-module FullPos : sig
-
-  (** [OpamPrinter] functions, with full position types *)
-
-  open OpamParserTypes.FullPos
-
-  val relop: [< relop_kind ] with_pos -> string
-  val logop: [< logop_kind ] with_pos -> string
-  val pfxop: [< pfxop_kind ] with_pos -> string
-  val env_update_op: env_update_op -> string
-
-  val relop_kind: [< relop_kind ] -> string
-  val logop_kind: [< logop_kind ] -> string
-  val pfxop_kind: [< pfxop_kind ] -> string
-  val env_update_op_kind: env_update_op_kind -> string
-
-  val value : value -> string
-  val value_list: value list with_pos -> string
-  val items: opamfile_item list -> string
-  val opamfile: opamfile -> string
-
-  val format_opamfile: Format.formatter -> opamfile -> unit
-
-  module Normalise : sig
-    val escape_string : string -> string
-    val value : value -> string
-    val item : opamfile_item -> string
-    val item_order : opamfile_item -> opamfile_item -> int
-    val items : opamfile_item list -> string
-    val opamfile : opamfile -> string
-  end
-
-  module Preserved : sig
-    val items: string -> opamfile_item list -> opamfile_item list -> string
-
-    val opamfile: ?format_from:file_name -> opamfile -> string
-  end
-
-  val value_equals: value -> value -> bool
-  val opamfile_item_equals: opamfile_item -> opamfile_item -> bool
-
-end

--- a/src/opamPrinter.mli
+++ b/src/opamPrinter.mli
@@ -15,49 +15,35 @@
 
 open OpamParserTypes
 
-val relop: [< relop_kind ] with_pos -> string
-(** Converts {!OpamParserTypes.rel_op} to its string representation
+val relop: [< relop ] -> string
+(** Converts {!OpamParserTypes.relop} to its string representation
     ([=], [!=], ..., [~]). *)
 
-val logop: [< logop_kind ] with_pos -> string
-(** Converts {!OpamParserTypes.log_op} to its string representation
+val logop: [< logop ] -> string
+(** Converts {!OpamParserTypes.logop} to its string representation
     ([&] and [|]). *)
 
-val pfxop: [< pfxop_kind ] with_pos -> string
-(** Converts {!OpamParserTypes.pfx_op} to its string representation
-    ([!] and [?]). *)
-
-val relop_kind: [< relop_kind ] -> string
-(** Converts {!OpamParserTypes.relop_kind} to its string representation
-    ([=], [!=], ..., [~]). *)
-
-val logop_kind: [< logop_kind ] -> string
-(** Converts {!OpamParserTypes.logop_kind} to its string representation
-    ([&] and [|]). *)
-
-val pfxop_kind: [< pfxop_kind ] -> string
-(** Converts {!OpamParserTypes.pfxop_kind} to its string representation
+val pfxop: [< pfxop ] -> string
+(** Converts {!OpamParserTypes.pfxop} to its string representation
     ([!] and [?]). *)
 
 val env_update_op: env_update_op -> string
 (** Converts {!OpamParserTypes.env_update_op} to its string representation
     ([=], [+=], ..., [=:]). *)
 
-val env_update_op_kind: env_update_op_kind -> string
-(** Converts {!OpamParserTypes.env_update_op_kind} to its string representation
-    ([=], [+=], ..., [=:]). *)
-
 val value : value -> string
 (** Converts {!value} to a string {b always using LF-encoding of newlines}. *)
 
-val value_list: value list with_pos -> string
+val value_list: value list -> string
 (** Converts a list of {!value}s to a string {b always using LF-encoding of
     newlines}. *)
 
 val items: opamfile_item list -> string
 
 val opamfile: opamfile -> string
-(** Converts an {!opamfile} to a string. *)
+(** Converts an {!opamfile} to a string, using the
+    {!OpamParserTypes.opamfile.file_crlf} field to determine how to encode line
+    endings. *)
 
 val format_opamfile: Format.formatter -> opamfile -> unit
 (** Writes an {!opamfile} to a [Format.formatter]. The function ensures that all
@@ -114,3 +100,47 @@ val value_equals: value -> value -> bool
 
 val opamfile_item_equals: opamfile_item -> opamfile_item -> bool
 (** Compares structurally, without considering file positions *)
+
+module FullPos : sig
+
+  (** [OpamPrinter] functions, with full position types *)
+
+  open OpamParserTypes.FullPos
+
+  val relop: [< relop_kind ] with_pos -> string
+  val logop: [< logop_kind ] with_pos -> string
+  val pfxop: [< pfxop_kind ] with_pos -> string
+  val env_update_op: env_update_op -> string
+
+  val relop_kind: [< relop_kind ] -> string
+  val logop_kind: [< logop_kind ] -> string
+  val pfxop_kind: [< pfxop_kind ] -> string
+  val env_update_op_kind: env_update_op_kind -> string
+
+  val value : value -> string
+  val value_list: value list with_pos -> string
+  val items: opamfile_item list -> string
+  val opamfile: opamfile -> string
+
+  val format_opamfile: Format.formatter -> opamfile -> unit
+
+  module Normalise : sig
+    val escape_string : string -> string
+    val value : value -> string
+    val item : opamfile_item -> string
+    val item_order : opamfile_item -> opamfile_item -> int
+    val items : opamfile_item list -> string
+    val opamfile : opamfile -> string
+  end
+
+  module Preserved : sig
+    val items: string -> opamfile_item list -> opamfile_item list -> string
+
+    val opamfile: ?format_from:file_name -> opamfile -> string
+  end
+
+  val value_equals: value -> value -> bool
+  val opamfile_item_equals: opamfile_item -> opamfile_item -> bool
+
+end
+

--- a/src/opamPrinter.mli
+++ b/src/opamPrinter.mli
@@ -16,36 +16,43 @@
 open OpamParserTypes
 
 val relop: [< relop ] -> string
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.relop instead."]
 (** Converts {!OpamParserTypes.relop} to its string representation
     ([=], [!=], ..., [~]). *)
 
 val logop: [< logop ] -> string
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.logop instead."]
 (** Converts {!OpamParserTypes.logop} to its string representation
     ([&] and [|]). *)
 
 val pfxop: [< pfxop ] -> string
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.pfxop instead."]
 (** Converts {!OpamParserTypes.pfxop} to its string representation
     ([!] and [?]). *)
 
 val env_update_op: env_update_op -> string
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.env_update_op instead."]
 (** Converts {!OpamParserTypes.env_update_op} to its string representation
     ([=], [+=], ..., [=:]). *)
 
 val value : value -> string
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.value instead."]
 (** Converts {!value} to a string {b always using LF-encoding of newlines}. *)
 
 val value_list: value list -> string
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.value_list instead."]
 (** Converts a list of {!value}s to a string {b always using LF-encoding of
     newlines}. *)
 
 val items: opamfile_item list -> string
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.items instead."]
 
 val opamfile: opamfile -> string
-(** Converts an {!opamfile} to a string, using the
-    {!OpamParserTypes.opamfile.file_crlf} field to determine how to encode line
-    endings. *)
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.opamfile instead."]
+(** Converts an {!opamfile} to a string. *)
 
 val format_opamfile: Format.formatter -> opamfile -> unit
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.format_opamfile instead."]
 (** Writes an {!opamfile} to a [Format.formatter]. The function ensures that all
     newlines are sent using [Format]'s break instructions (and so ultimately are
     processed with the [out_newline] function of the formatter) but it is the
@@ -77,6 +84,7 @@ module Normalise : sig
   val items : opamfile_item list -> string
   val opamfile : opamfile -> string
 end
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.Normalise instead."]
 
 (** {2 Format-preserving reprinter} *)
 
@@ -92,13 +100,16 @@ module Preserved : sig
       the corresponding on-disk file for unmodified items. [format_from] can be
       specified instead of using the filename specified in [f]. *)
 end
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.Preserved instead."]
 
 (** {2 Random utility functions} *)
 
 val value_equals: value -> value -> bool
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.value_equals instead."]
 (** Compares structurally, without considering file positions *)
 
 val opamfile_item_equals: opamfile_item -> opamfile_item -> bool
+[@@ocaml.deprecated "Use OpamPrinter.FullPos.opamfile_item_equals instead."]
 (** Compares structurally, without considering file positions *)
 
 module FullPos : sig
@@ -143,4 +154,3 @@ module FullPos : sig
   val opamfile_item_equals: opamfile_item -> opamfile_item -> bool
 
 end
-

--- a/src/opamPrinter.mli
+++ b/src/opamPrinter.mli
@@ -36,16 +36,16 @@ module FullPos : sig
       ([=], [+=], ..., [=:]). *)
 
 
-  val relop: rel_op -> string
-  (** Converts {!OpamParserTypes.FullPos.rel_op} to its string representation
+  val relop: relop -> string
+  (** Converts {!OpamParserTypes.FullPos.relop} to its string representation
       ([=], [!=], ..., [~]). *)
 
-  val logop: log_op -> string
-  (** Converts {!OpamParserTypes.FullPos.log_op} to its string representation
+  val logop: logop -> string
+  (** Converts {!OpamParserTypes.FullPos.logop} to its string representation
       ([&] and [|]). *)
 
-  val pfxop: pfx_op -> string
-  (** Converts {!OpamParserTypes.FullPos.pfx_op} to its string representation
+  val pfxop: pfxop -> string
+  (** Converts {!OpamParserTypes.FullPos.pfxop} to its string representation
       ([!] and [?]). *)
 
   val env_update_op: env_update_op -> string

--- a/src/opamPrinter.mli
+++ b/src/opamPrinter.mli
@@ -15,26 +15,42 @@
 
 open OpamParserTypes
 
-val relop: [< relop ] -> string
-(** Converts {!OpamParserTypes.relop} to its string representation
+val relop: [< relop_kind ] with_pos -> string
+(** Converts {!OpamParserTypes.rel_op} to its string representation
     ([=], [!=], ..., [~]). *)
 
-val logop: [< logop ] -> string
-(** Converts {!OpamParserTypes.logop} to its string representation
+val logop: [< logop_kind ] with_pos -> string
+(** Converts {!OpamParserTypes.log_op} to its string representation
     ([&] and [|]). *)
 
-val pfxop: [< pfxop ] -> string
-(** Converts {!OpamParserTypes.pfxop} to its string representation
+val pfxop: [< pfxop_kind ] with_pos -> string
+(** Converts {!OpamParserTypes.pfx_op} to its string representation
+    ([!] and [?]). *)
+
+val relop_kind: [< relop_kind ] -> string
+(** Converts {!OpamParserTypes.relop_kind} to its string representation
+    ([=], [!=], ..., [~]). *)
+
+val logop_kind: [< logop_kind ] -> string
+(** Converts {!OpamParserTypes.logop_kind} to its string representation
+    ([&] and [|]). *)
+
+val pfxop_kind: [< pfxop_kind ] -> string
+(** Converts {!OpamParserTypes.pfxop_kind} to its string representation
     ([!] and [?]). *)
 
 val env_update_op: env_update_op -> string
 (** Converts {!OpamParserTypes.env_update_op} to its string representation
     ([=], [+=], ..., [=:]). *)
 
+val env_update_op_kind: env_update_op_kind -> string
+(** Converts {!OpamParserTypes.env_update_op_kind} to its string representation
+    ([=], [+=], ..., [=:]). *)
+
 val value : value -> string
 (** Converts {!value} to a string {b always using LF-encoding of newlines}. *)
 
-val value_list: value list -> string
+val value_list: value list with_pos -> string
 (** Converts a list of {!value}s to a string {b always using LF-encoding of
     newlines}. *)
 

--- a/tests/fullpos.ml
+++ b/tests/fullpos.ml
@@ -1,0 +1,504 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2020 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+open OpamParserTypes.FullPos
+open Utils
+module A = Alcotest
+
+(* utils *)
+
+let fd = "<nofile>"
+let np pelem =
+  { pos = { filename = fd; start = (0,0); stop = (0,0) };
+    pelem }
+
+let nullify_list l = List.map (fun (n,s,v) -> n,s,np v) l
+
+module Value = struct
+
+  let int0 = np @@ Int 0
+  let intmax = np @@ Int max_int
+  let sfoo = np @@ String "foo"
+  let sbar = np @@ String "bar"
+  let sempty = np @@ String ""
+  let btrue = np @@ Bool true
+  let bfalse = np @@ Bool false
+  let a = np @@ Ident "a"
+  let b = np @@ Ident "b"
+  let c = np @@ Ident "c"
+  let d = np @@ Ident "d"
+
+  let simple = [
+    "int", "0", int0;
+    "max_int", (Printf.sprintf "%d" max_int), intmax;
+    "string", "\"foo\"", sfoo;
+    "string", "\"bar\"", sbar;
+    "empty string", "\"\"", sempty;
+    "true", "true", btrue;
+    "false", "false", bfalse;
+    "ident", "a", a;
+    "ident", "b", b;
+  ]
+
+  let relop = [ (* printed with a space *)
+    "equal",             "=",   `Eq;
+    "not-equal",         "!=",  `Neq;
+    "greater-or-equal",  ">=",  `Geq;
+    "greater-than",      ">",   `Gt;
+    "lesser-or-equal",   "<=",  `Leq;
+    "lesser-than",       "<",   `Lt;
+  ]
+  let logop = [
+    "disj",  "&",  `And;
+    "conj",  "|",  `Or;
+  ]
+  let pfxop = [
+    "not",      "!",  `Not;
+    "defined",  "?",  `Defined;
+  ]
+  let env_update_op : (string *  string * env_update_op_kind ) list = [
+    (*   "equal",             "=",    Eq; *)
+    "plus-equal",        "+=",   PlusEq;
+    "equal-plus",        "=+",   EqPlus;
+    "colon-equal",       ":=",   ColonEq;
+    "equal-colon",       "=:",   EqColon;
+    "equal-plus-equal",  "=+=",  EqPlusEq;
+  ]
+
+  let unop ?(space=false) () =
+    let (^^) a b = if space then a^" "^b else a^b in
+    let args = simple in
+    let fold unop f =
+      List.fold_left (fun acc op -> acc @ List.map (fun arg -> f op arg) args)
+        [] unop
+    in
+    ((fold pfxop @@ fun (n,sop,op) (n', sarg, arg) ->
+      (n^" "^n', sop^sarg, Pfxop (np op, arg)))
+     @
+     (fold relop @@ fun (n,sop,op) (n', sarg, arg) ->
+      (n^" "^n', sop^^sarg, Prefix_relop (np op, arg))))
+    |> nullify_list
+
+  let binop ?(space=false) () =
+    let (^^) a b = if space then a^" "^b else a^b in
+    let args =
+      List.fold_left (fun acc x -> acc @ List.map (fun y -> (x,y)) simple)
+        [] simple
+    in
+    let fold binop f =
+      List.fold_left (fun acc op -> acc @ List.map (fun (arg1,arg2) ->
+          f op arg1 arg2) args) [] binop
+    in
+    ((fold relop @@ fun (n,sop,op) (n1, sarg1, arg1) (n2, sarg2, arg2) ->
+      (n1^" "^n^" "^n2, sarg1^^sop^^sarg2, Relop (np op, arg1, arg2)))
+     @
+     (fold logop @@ fun (n,sop,op) (n1, sarg1, arg1) (n2, sarg2, arg2) ->
+      (n1^" "^n^" "^n2, sarg1^^sop^^sarg2, Logop (np op, arg1, arg2)))
+     @
+     (fold env_update_op @@ fun (n,sop,op) (n1, sarg1, arg1) (n2, sarg2, arg2) ->
+      (n1^" "^n^" "^n2, sarg1^^sop^^sarg2, Env_binding (arg1, np op, arg2))))
+    |> nullify_list
+
+  let lists ?(space=false) () =
+    let s = if space then " " else "" in
+    let slist, list = List.(split (map (fun (_,a,b) -> a,b) simple)) in
+    [
+      "list",
+      Printf.sprintf "[%s%s%s]" s (String.concat " " slist) s,
+      np @@ List (np list);
+      "group",
+      Printf.sprintf "(%s%s%s)" s (String.concat " " slist) s,
+      np @@ Group (np list);
+    ]
+    @
+    (List.map (fun (n,sarg,arg) ->
+         "option "^n,
+         Printf.sprintf "%s {%s%s%s}" sarg s (String.concat " " slist) s,
+         np @@ Option (arg, np list))
+        simple)
+
+  let and_or () =
+    [
+      "and-or", "a & (b | c)",
+      Logop (np `And, a, np @@ Group (np [np @@ Logop (np `Or, b, c)]));
+      "or-and", "a | b & c",
+      Logop (np `Or, a, np @@ Logop (np `And, b, c));
+      "or-and", "a & b | c",
+      Logop (np `Or, np @@ Logop (np `And, a, b), c);
+      "or-and-and", "a & b | c & d",
+      Logop (np `Or, np @@ Logop (np `And, a, b), np @@ Logop (np `And, c, d));
+      "or-and-and", "(a & b) | (c & d)",
+      Logop (np `Or, np @@ Group (np [np @@ Logop (np `And, a, b)]),
+             np @@ Group (np [np @@ Logop (np `And, c, d)]));
+      "or-or-and", "a | b & c | d",
+      Logop (np `Or, np @@ Logop (np `Or, a, np @@ Logop (np `And, b, c)), d);
+      "and-or-or", "(a | b) & (c | d)",
+      Logop (np `And, np @@ Group (np [np @@ Logop (np `Or, a, b)]),
+             np @@ Group (np [np @@ Logop (np `Or, c, d)]));
+    ]
+    |> nullify_list
+
+  let print_value v =
+    OpamPrinter.FullPos.value v
+    |> split_on_char '\n'
+    |> List.map (fun s ->
+        try
+          if s.[0] = ' ' then String.sub s 1 (String.length s - 1)
+          else s
+        with Invalid_argument _ -> s)
+    |> String.concat ""
+
+  let parse_value s =
+    OpamParser.FullPos.value_from_string s fd
+
+  let value_testable =
+    let value_fmt : value Fmt.t = fun ppf v ->
+      Format.fprintf ppf "%s" (OpamPrinter.FullPos.value v)
+    in
+    A.testable value_fmt OpamPrinter.FullPos.value_equals
+
+  let test_printer t () =
+    List.iter (fun (name, str, value) ->
+        A.check A.string name str (print_value value))
+      t
+
+  let test_parser t () =
+    List.iter (fun (name, str, value) ->
+        A.check value_testable name value (parse_value str))
+      t
+
+  let test_parser_printer t () =
+    List.iter (fun (name, str, _) ->
+        A.check A.string name str
+          (print_value (parse_value str)))
+      t
+
+  let space = true
+  let printer = [
+    "simple",   test_printer simple;
+    "unop",     test_printer @@ unop ~space ();
+    "binop",    test_printer @@ binop ~space ();
+    "lists",    test_printer @@ lists ();
+    "and_or",   test_printer @@ and_or ();
+  ]
+
+  let parser = [
+    "simple",   test_parser simple;
+    "unop",     test_parser @@ unop ();
+    "binop",    test_parser @@ binop ();
+    "lists",    test_parser @@ lists ~space ();
+    "and_or",    test_parser @@ and_or ();
+  ]
+
+  let parser_printer = [
+    "simple",   test_parser_printer simple;
+    "unop",     test_parser_printer @@ unop ~space ();
+    "binop",    test_parser_printer @@ binop ~space ();
+    "lists",    test_parser_printer @@ lists ();
+    "and_or",    test_parser_printer @@ and_or ();
+  ]
+
+  let tests =
+    List.fold_left (fun acc (n, t) ->
+        (List.map (fun (n', t') -> n^" "^n', t') t) @ acc) []
+      [
+        "printer", printer;
+        "parser", parser;
+        "parser-printer", parser_printer;
+      ]
+end
+
+module Item = struct
+
+  let variables =
+    let space = true in
+    let get_name pre n =
+      String.map (fun c -> if c = ' ' then '-' else c) (pre^"-"^n)
+    in
+    [
+      List.map (fun (n,s,v) ->
+          let name = get_name "simple" n in
+          name, Printf.sprintf "%s: %s" name s, Variable (np name, v))
+        Value.simple;
+      List.map (fun (n,s,v) ->
+          let name = get_name "unop" n in
+          name, Printf.sprintf "%s: %s" name s, Variable (np name, v))
+        (Value.unop ~space ());
+      List.map (fun (n,s,v) ->
+          let name = get_name "binop" n in
+          name, Printf.sprintf "%s: %s" name s, Variable (np name, v))
+        (Value.binop ~space ());
+      List.map (fun (n,s,v) ->
+          let name = get_name "lists" n in
+          name, Printf.sprintf "%s: %s" name s, Variable (np name, v))
+        (Value.lists  ());
+    ]
+    |> List.flatten
+    |> nullify_list
+
+  let sections =
+    let section_wname = function
+      | { pelem = Section sec; _} ->
+        np @@ Section ({ sec with section_name = Some (np "a-name") })
+      | _ -> raise (Invalid_argument "section_wname")
+    in
+    let str_section_wname = add_after_first ' ' "\"a-name\" " in
+    let sec ?(inner=false) kind items str_items =
+      let padding = if inner then "  " else "" in
+      kind, Printf.sprintf "%s {\n  %s%s\n%s}"
+        kind padding str_items padding ,
+      np @@ Section ({ section_kind = np kind;
+                       section_name = None;
+                       section_items = np items })
+    in
+    let v1,s1, v2,s2, v3,s3 =
+      match  variables with
+      | (_,s1,v1)::_::(_,s2,v2)::_::_::(_,s3,v3)::_ ->
+        v1,s1, v2,s2, v3,s3
+      | _ -> assert false
+    in
+    let empty ?inner () = sec ?inner "section-empty" [] "" in
+    let one_item ?inner () =
+      sec ?inner "section-with-one-item" [v1] s1
+    in
+    let more_items ?inner () =
+      sec ?inner "section-with-more-items" [ v1; v2; v3 ]
+        (let padding = if inner = Some true then "  " else "" in
+         Printf.sprintf "%s\n  %s%s\n  %s%s" s1 padding s2 padding s3)
+    in
+    let sec_w_esec =
+      let _, estr, esec = empty ~inner:true () in
+      sec "section-w-empty-section" [esec] estr
+    in
+    let sec_w_osec =
+      let _, ostr, osec = one_item ~inner:true () in
+      sec "section-w-1item-section" [osec] ostr
+    in
+    let sec_w_item_sec =
+      let _, ostr, osec = one_item ~inner:true () in
+      sec "section-w-item--asection" [v1; osec]
+        (Printf.sprintf "%s\n  %s" s1 ostr)
+    in
+    let sec_w_sec_item =
+      let _, ostr, osec = one_item ~inner:true () in
+      sec "section-w-section-a-item" [osec; v2]
+        (Printf.sprintf "%s\n  %s" ostr s2)
+    in
+    let sec_w_secs_and_items =
+      let _, estr, esec = empty ~inner:true () in
+      let _, ostr, osec = one_item ~inner:true () in
+      let _, mstr, msec = more_items ~inner:true () in
+      sec "section-w-sections-a-items"
+        [ v1; esec; section_wname osec; v2; v3; msec ]
+        (String.concat "\n  " [ s1; estr; str_section_wname ostr; s2; s3; mstr ])
+    in
+    List.fold_left (fun acc (n,s,i as section) ->
+        (n^"-with-name", str_section_wname s, section_wname i)::section::acc) []
+      [
+        empty ();
+        one_item ();
+        more_items ();
+        sec_w_esec;
+        sec_w_osec;
+        sec_w_item_sec;
+        sec_w_sec_item;
+        sec_w_secs_and_items;
+      ] |> List.rev
+
+
+  let newline =
+    add_after_first ~cond:(fun s -> String.length s > 78 (* ??? *)) ':' "\n "
+
+  let parse_item item  =
+    match (OpamParser.FullPos.string item fd).file_contents with
+    | [x] -> x
+    | _ -> failwith "irrelevant"
+
+  let print_item item =
+    OpamPrinter.FullPos.items [item]
+
+  let item_testable =
+    let item_fmt : opamfile_item Fmt.t = fun ppf i ->
+      Format.fprintf ppf "%s" (OpamPrinter.FullPos.items [i])
+    in
+    A.testable item_fmt OpamPrinter.FullPos.opamfile_item_equals
+
+  let test_printer ?nl t () =
+    let newline = if nl <> None then newline else fun s -> s in
+    List.iter (fun (name, str, item) ->
+        A.check A.string name (newline str) (print_item item))
+      t
+
+  let test_parser t () =
+    List.iter (fun (name, str, item) ->
+        A.check item_testable name item (parse_item str))
+      t
+
+  let test_parser_printer ?nl t () =
+    let newline = if nl <> None then newline else fun s -> s in
+    List.iter (fun (name, str, _) ->
+        A.check A.string name (newline str)
+          (print_item (parse_item str)))
+      t
+
+  let tests =
+    [
+      "variable printer", test_printer ~nl:true variables;
+      "variable parser", test_parser variables;
+      "variable parser-printer", test_parser_printer ~nl:true variables;
+
+      "section printer", test_printer sections;
+      "section parser", test_parser sections;
+      "section parser-printer", test_parser_printer sections;
+    ]
+
+end
+
+module Opamfile = struct
+
+  let opamfiles, opamfiles_comment =
+    let ofile contents = { file_contents = contents; file_name = fd } in
+    let empty = "empty", "", ofile [] in
+    let one_item =
+      let _, str, item =
+        match Item.variables with
+        | x::_ -> x
+        | _ -> assert false
+      in
+      "one-item", str, ofile [item]
+    in
+    let one_section =
+      let _, str, section =
+        match Item.sections with
+        | _::x::_ -> x
+        | _ -> assert false
+      in
+      "one-section", str, ofile [section]
+    in
+    let full =
+      let all = Item.((List.map (fun (n,s,v) -> n, newline s, v) variables) @ sections) in
+      let str = String.concat "\n" (List.map (fun (_,s,_) -> s) all) in
+      let items = List.map (fun (_,_,i) -> i) all in
+      "all", str, ofile items
+    in
+    let add_comment before (name, str, it) =
+      name,
+      (if before then "#tautological comment\n"^str else str^"\n#tautological comment"),
+      it
+    in
+    [
+      empty;
+      one_item;
+      one_section;
+      full;
+    ], [
+      add_comment true empty;
+      add_comment true one_item;
+      add_comment false one_section;
+    ]
+
+  let print_ofile = OpamPrinter.FullPos.opamfile
+  let parse_ofile s = OpamParser.FullPos.string s fd
+
+  let ofile_testable =
+    let opamfile_fmt : opamfile Fmt.t = fun ppf f ->
+      Format.fprintf ppf "%s" (OpamPrinter.FullPos.opamfile f)
+    in
+    let opamfile_equals o1 o2 =
+      let rec aux o1 o2 =
+        match o1, o2 with
+        | i1::l1, i2::l2 ->
+          OpamPrinter.FullPos.opamfile_item_equals i1 i2 || aux l1 l2
+        | [], [] ->  true
+        | _, _ -> false
+      in
+      aux o1.file_contents o2.file_contents
+    in
+    A.testable opamfile_fmt opamfile_equals
+
+  let test_printer t () =
+    List.iter (fun (name, str, ofile) ->
+        A.check A.string name str (print_ofile ofile))
+      t
+
+  let test_parser t () =
+    List.iter (fun (name, str, ofile) ->
+        A.check ofile_testable name ofile (parse_ofile str))
+      t
+
+  let test_parser_printer t () =
+    List.iter (fun (name, str, _) ->
+        A.check A.string name str
+          (print_ofile (parse_ofile str)))
+      t
+
+  let positions () =
+    let filename = Sys.getcwd () ^ "/sample.opam" in
+    let spos start stop = {filename; start; stop } in
+    let file_contents =
+      [
+        { pos = spos (1, 0) (1, 6);
+          pelem =
+            Variable
+              ({ pos = spos (1, 0) (1, 3);
+                 pelem = "int" },
+               { pos = spos (1, 5) (1, 6);
+                 pelem = Int 0 });
+        };
+        { pos = spos (2, 0) (2, 13);
+          pelem =
+            Variable
+              ({ pos = spos (2, 0) (2, 6);
+                 pelem = "string" },
+               { pos = spos (2, 8) (2, 13);
+                 pelem = String "foo" });
+        };
+        { pos = spos (4, 0) (5, 29);
+          pelem =
+            Section
+              { section_kind =
+                  { pos = spos (4, 0) (4, 7);
+                    pelem = "section" };
+                section_name =
+                  Some { pos = spos (4, 8) (4, 15);
+                         pelem = "thing" };
+                section_items =
+                  { pos = spos (4, 8) (5, 29);
+                    pelem =
+                      [{ pos = spos (5, 2) (5, 29);
+                         pelem =
+                           Variable
+                             ({ pos = spos (5, 2) (5, 5); pelem = "url"},
+                              { pos = spos (5, 7) (5, 29);
+                                pelem = String "https://theinter.net" });
+                       }];
+                  }
+              };
+        }
+      ];
+    in
+    let content = {file_contents; file_name = filename} in
+    A.check ofile_testable "sample" content (OpamParser.FullPos.file filename)
+
+  let tests =
+    [
+      "parser", test_parser (opamfiles @ opamfiles_comment);
+      "printer", test_printer opamfiles;
+      "parser-printer", test_parser_printer opamfiles;
+      "positions-file", positions;
+    ]
+
+end
+
+let tests = [
+  "values", Value.tests;
+  "items", Item.tests;
+  "opamfile", Opamfile.tests;
+] |> List.map (fun (n,t) -> "fullpos "^n, t)

--- a/tests/oldpos.ml
+++ b/tests/oldpos.ml
@@ -1,0 +1,472 @@
+(**************************************************************************)
+(*                                                                        *)
+(*    Copyright 2020 OCamlPro                                             *)
+(*                                                                        *)
+(*  All rights reserved. This file is distributed under the terms of the  *)
+(*  GNU Lesser General Public License version 2.1, with the special       *)
+(*  exception on linking described in the file LICENSE.                   *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "-3"]
+
+open OpamParserTypes
+open Utils
+module A = Alcotest
+
+(* utils *)
+
+let null = ("", 0, 0)
+let fd = "<nofile>"
+
+module Value = struct
+
+  let int0 = Int (null, 0)
+  let intmax = Int (null, max_int)
+  let sfoo = String (null, "foo")
+  let sbar = String (null, "bar")
+  let sempty = String (null, "")
+  let btrue = Bool (null, true)
+  let bfalse = Bool (null, false)
+  let a = Ident (null, "a")
+  let b = Ident (null, "b")
+  let c = Ident (null, "c")
+  let d = Ident (null, "d")
+
+  let simple = [
+    "int", "0", int0;
+    "max_int", (Printf.sprintf "%d" max_int), intmax;
+    "string", "\"foo\"", sfoo;
+    "string", "\"bar\"", sbar;
+    "empty string", "\"\"", sempty;
+    "true", "true", btrue;
+    "false", "false", bfalse;
+    "ident", "a", a;
+    "ident", "b", b;
+  ]
+
+  let relop = [ (* printed with a space *)
+    "equal",             "=",   `Eq;
+    "not-equal",         "!=",  `Neq;
+    "greater-or-equal",  ">=",  `Geq;
+    "greater-than",      ">",   `Gt;
+    "lesser-or-equal",   "<=",  `Leq;
+    "lesser-than",       "<",   `Lt;
+  ]
+  let logop = [
+    "disj",  "&",  `And;
+    "conj",  "|",  `Or;
+  ]
+  let pfxop = [
+    "not",      "!",  `Not;
+    "defined",  "?",  `Defined;
+  ]
+  let env_update_op = [
+    (*   "equal",             "=",    Eq; *)
+    "plus-equal",        "+=",   PlusEq;
+    "equal-plus",        "=+",   EqPlus;
+    "colon-equal",       ":=",   ColonEq;
+    "equal-colon",       "=:",   EqColon;
+    "equal-plus-equal",  "=+=",  EqPlusEq;
+  ]
+
+  let unop ?(space=false) () =
+    let (^^) a b = if space then a^" "^b else a^b in
+    let args = simple in
+    let fold unop f =
+      List.fold_left (fun acc op -> acc @ List.map (fun arg -> f op arg) args)
+        [] unop
+    in
+    (fold pfxop @@ fun (n,sop,op) (n', sarg, arg) ->
+     (n^" "^n', sop^sarg, Pfxop (null, op, arg)))
+    @
+    (fold relop @@ fun (n,sop,op) (n', sarg, arg) ->
+     (n^" "^n', sop^^sarg, Prefix_relop (null, op, arg)))
+
+  let binop ?(space=false) () =
+    let (^^) a b = if space then a^" "^b else a^b in
+    let args =
+      List.fold_left (fun acc x -> acc @ List.map (fun y -> (x,y)) simple)
+        [] simple
+    in
+    let fold binop f =
+      List.fold_left (fun acc op -> acc @ List.map (fun (arg1,arg2) ->
+          f op arg1 arg2) args) [] binop
+    in
+    (fold relop @@ fun (n,sop,op) (n1, sarg1, arg1) (n2, sarg2, arg2) ->
+     (n1^" "^n^" "^n2, sarg1^^sop^^sarg2, Relop (null, op, arg1, arg2)))
+    @
+    (fold logop @@ fun (n,sop,op) (n1, sarg1, arg1) (n2, sarg2, arg2) ->
+     (n1^" "^n^" "^n2, sarg1^^sop^^sarg2, Logop (null, op, arg1, arg2)))
+    @
+    (fold env_update_op @@ fun (n,sop,op) (n1, sarg1, arg1) (n2, sarg2, arg2) ->
+     (n1^" "^n^" "^n2, sarg1^^sop^^sarg2, Env_binding (null, arg1, op, arg2)))
+
+  let lists ?(space=false) () =
+    let s = if space then " " else "" in
+    let slist, list = List.(split (map (fun (_,a,b) -> a,b) simple)) in
+    [
+      "list",
+      Printf.sprintf "[%s%s%s]" s (String.concat " " slist) s,
+      List (null, list);
+      "group",
+      Printf.sprintf "(%s%s%s)" s (String.concat " " slist) s,
+      Group (null, list);
+    ]
+    @
+    (List.map (fun (n,sarg,arg) ->
+         "option "^n,
+         Printf.sprintf "%s {%s%s%s}" sarg s (String.concat " " slist) s,
+         Option (null, arg, list))
+        simple)
+
+  let and_or () =
+    [
+      "and-or", "a & (b | c)",
+      Logop (null,`And, a, Group (null, [Logop (null, `Or, b, c)]));
+      "or-and", "a | b & c",
+      Logop (null, `Or, a, Logop (null, `And, b, c));
+      "or-and", "a & b | c",
+      Logop (null, `Or, Logop (null, `And, a, b), c);
+      "or-and-and", "a & b | c & d",
+      Logop (null, `Or, Logop (null, `And, a, b), Logop (null, `And, c, d));
+      "or-and-and", "(a & b) | (c & d)",
+      Logop (null, `Or, Group (null, [Logop (null, `And, a, b)]),
+             Group (null, [Logop (null, `And, c, d)]));
+      "or-or-and", "a | b & c | d",
+      Logop (null, `Or, Logop (null, `Or, a, Logop (null, `And, b, c)), d);
+      "and-or-or", "(a | b) & (c | d)",
+      Logop (null, `And, Group (null, [Logop (null, `Or, a, b)]),
+             Group (null, [Logop (null, `Or, c, d)]));
+    ]
+
+  let print_value v =
+    OpamPrinter.value v
+    |> split_on_char '\n'
+    |> List.map (fun s ->
+        try
+          if s.[0] = ' ' then String.sub s 1 (String.length s - 1)
+          else s
+        with Invalid_argument _ -> s)
+    |> String.concat ""
+
+  let parse_value s =
+    OpamParser.value_from_string s fd
+
+  let value_testable =
+    let value_fmt : value Fmt.t = fun ppf v ->
+      Format.fprintf ppf "%s" (OpamPrinter.value v)
+    in
+    A.testable value_fmt OpamPrinter.value_equals
+
+  let test_printer t () =
+    List.iter (fun (name, str, value) ->
+        A.check A.string name str (print_value value))
+      t
+
+  let test_parser t () =
+    List.iter (fun (name, str, value) ->
+        A.check value_testable name value (parse_value str))
+      t
+
+  let test_parser_printer t () =
+    List.iter (fun (name, str, _) ->
+        A.check A.string name str
+          (print_value (parse_value str)))
+      t
+
+  let space = true
+  let printer = [
+    "simple",   test_printer simple;
+    "unop",     test_printer @@ unop ~space ();
+    "binop",    test_printer @@ binop ~space ();
+    "lists",    test_printer @@ lists ();
+    "and_or",   test_printer @@ and_or ();
+  ]
+
+  let parser = [
+    "simple",   test_parser simple;
+    "unop",     test_parser @@ unop ();
+    "binop",    test_parser @@ binop ();
+    "lists",    test_parser @@ lists ~space ();
+    "and_or",    test_parser @@ and_or ();
+  ]
+
+  let parser_printer = [
+    "simple",   test_parser_printer simple;
+    "unop",     test_parser_printer @@ unop ~space ();
+    "binop",    test_parser_printer @@ binop ~space ();
+    "lists",    test_parser_printer @@ lists ();
+    "and_or",    test_parser_printer @@ and_or ();
+  ]
+
+  let tests =
+    List.fold_left (fun acc (n, t) ->
+        (List.map (fun (n', t') -> n^" "^n', t') t) @ acc) []
+      [
+        "printer", printer;
+        "parser", parser;
+        "parser-printer", parser_printer;
+      ]
+end
+
+module Item = struct
+
+  let variables =
+    let space = true in
+    let get_name pre n =
+      String.map (fun c -> if c = ' ' then '-' else c) (pre^"-"^n)
+    in
+    [
+      List.map (fun (n,s,v) ->
+          let name = get_name "simple" n in
+          name, Printf.sprintf "%s: %s" name s, Variable (null, name, v))
+        Value.simple;
+      List.map (fun (n,s,v) ->
+          let name = get_name "unop" n in
+          name, Printf.sprintf "%s: %s" name s, Variable (null, name, v))
+        (Value.unop ~space ());
+      List.map (fun (n,s,v) ->
+          let name = get_name "binop" n in
+          name, Printf.sprintf "%s: %s" name s, Variable (null, name, v))
+        (Value.binop ~space ());
+      List.map (fun (n,s,v) ->
+          let name = get_name "lists" n in
+          name, Printf.sprintf "%s: %s" name s, Variable (null, name, v))
+        (Value.lists  ());
+    ]
+    |> List.flatten
+
+  let sections =
+    let section_wname = function
+      | Section (_, sec) ->
+        Section (null, { sec with section_name = Some "a-name" })
+      | Variable _ -> raise (Invalid_argument "section_wname")
+    in
+    let str_section_wname = add_after_first ' ' "\"a-name\" " in
+    let sec ?(inner=false) kind items str_items =
+      let padding = if inner then "  " else "" in
+      kind, Printf.sprintf "%s {\n  %s%s\n%s}"
+        kind padding str_items padding ,
+      Section (null, { section_kind = kind;
+                       section_name = None;
+                       section_items = items })
+    in
+    let v1,s1, v2,s2, v3,s3 =
+      match  variables with
+      | (_,s1,v1)::_::(_,s2,v2)::_::_::(_,s3,v3)::_ ->
+        v1,s1, v2,s2, v3,s3
+      | _ -> assert false
+    in
+    let empty ?inner () = sec ?inner "section-empty" [] "" in
+    let one_item ?inner () =
+      sec ?inner "section-with-one-item" [v1] s1
+    in
+    let more_items ?inner () =
+      sec ?inner "section-with-more-items" [ v1; v2; v3 ]
+        (let padding = if inner = Some true then "  " else "" in
+         Printf.sprintf "%s\n  %s%s\n  %s%s" s1 padding s2 padding s3)
+    in
+    let sec_w_esec =
+      let _, estr, esec = empty ~inner:true () in
+      sec "section-w-empty-section" [esec] estr
+    in
+    let sec_w_osec =
+      let _, ostr, osec = one_item ~inner:true () in
+      sec "section-w-1item-section" [osec] ostr
+    in
+    let sec_w_item_sec =
+      let _, ostr, osec = one_item ~inner:true () in
+      sec "section-w-item--asection" [v1; osec]
+        (Printf.sprintf "%s\n  %s" s1 ostr)
+    in
+    let sec_w_sec_item =
+      let _, ostr, osec = one_item ~inner:true () in
+      sec "section-w-section-a-item" [osec; v2]
+        (Printf.sprintf "%s\n  %s" ostr s2)
+    in
+    let sec_w_secs_and_items =
+      let _, estr, esec = empty ~inner:true () in
+      let _, ostr, osec = one_item ~inner:true () in
+      let _, mstr, msec = more_items ~inner:true () in
+      sec "section-w-sections-a-items"
+        [ v1; esec; section_wname osec; v2; v3; msec ]
+        (String.concat "\n  " [ s1; estr; str_section_wname ostr; s2; s3; mstr ])
+    in
+    List.fold_left (fun acc (n,s,i as section) ->
+        (n^"-with-name", str_section_wname s, section_wname i)::section::acc) []
+      [
+        empty ();
+        one_item ();
+        more_items ();
+        sec_w_esec;
+        sec_w_osec;
+        sec_w_item_sec;
+        sec_w_sec_item;
+        sec_w_secs_and_items;
+      ] |> List.rev
+
+
+  let newline =
+    add_after_first ~cond:(fun s -> String.length s > 78 (* ??? *)) ':' "\n "
+
+  let parse_item item  =
+    match (OpamParser.string item fd).file_contents with
+    | [x] -> x
+    | _ -> failwith "irrelevant"
+
+  let print_item item =
+    OpamPrinter.items [item]
+
+  let item_testable =
+    let item_fmt : opamfile_item Fmt.t = fun ppf i ->
+      Format.fprintf ppf "%s" (OpamPrinter.items [i])
+    in
+    A.testable item_fmt OpamPrinter.opamfile_item_equals
+
+  let test_printer ?nl t () =
+    let newline = if nl <> None then newline else fun s -> s in
+    List.iter (fun (name, str, item) ->
+        A.check A.string name (newline str) (print_item item))
+      t
+
+  let test_parser t () =
+    List.iter (fun (name, str, item) ->
+        A.check item_testable name item (parse_item str))
+      t
+
+  let test_parser_printer ?nl t () =
+    let newline = if nl <> None then newline else fun s -> s in
+    List.iter (fun (name, str, _) ->
+        A.check A.string name (newline str)
+          (print_item (parse_item str)))
+      t
+
+  let tests =
+    [
+      "variable printer", test_printer ~nl:true variables;
+      "variable parser", test_parser variables;
+      "variable parser-printer", test_parser_printer ~nl:true variables;
+
+      "section printer", test_printer sections;
+      "section parser", test_parser sections;
+      "section parser-printer", test_parser_printer sections;
+    ]
+
+end
+
+module Opamfile = struct
+
+  let opamfiles, opamfiles_comment =
+    let ofile contents = { file_contents = contents; file_name = fd } in
+    let empty = "empty", "", ofile [] in
+    let one_item =
+      let _, str, item =
+        match Item.variables with
+        | x::_ -> x
+        | _ -> assert false
+      in
+      "one-item", str, ofile [item]
+    in
+    let one_section =
+      let _, str, section =
+        match Item.sections with
+        | _::x::_ -> x
+        | _ -> assert false
+      in
+      "one-section", str, ofile [section]
+    in
+    let full =
+      let all = Item.((List.map (fun (n,s,v) -> n, newline s, v) variables) @ sections) in
+      let str = String.concat "\n" (List.map (fun (_,s,_) -> s) all) in
+      let items = List.map (fun (_,_,i) -> i) all in
+      "all", str, ofile items
+    in
+    let add_comment before (name, str, it) =
+      name,
+      (if before then "#tautological comment\n"^str else str^"\n#tautological comment"),
+      it
+    in
+    [
+      empty;
+      one_item;
+      one_section;
+      full;
+    ], [
+      add_comment true empty;
+      add_comment true one_item;
+      add_comment false one_section;
+    ]
+
+  let print_ofile = OpamPrinter.opamfile
+  let parse_ofile s = OpamParser.string s fd
+
+  let ofile_testable =
+    let opamfile_fmt : opamfile Fmt.t = fun ppf f ->
+      Format.fprintf ppf "%s" (OpamPrinter.opamfile f)
+    in
+    let opamfile_equals o1 o2 =
+      let rec aux o1 o2 =
+        match o1, o2 with
+        | i1::l1, i2::l2 ->
+          OpamPrinter.opamfile_item_equals i1 i2 || aux l1 l2
+        | [], [] ->  true
+        | _, _ -> false
+      in
+      aux o1.file_contents o2.file_contents
+    in
+    A.testable opamfile_fmt opamfile_equals
+
+  let test_printer t () =
+    List.iter (fun (name, str, ofile) ->
+        A.check A.string name str (print_ofile ofile))
+      t
+
+  let test_parser t () =
+    List.iter (fun (name, str, ofile) ->
+        A.check ofile_testable name ofile (parse_ofile str))
+      t
+
+  let test_parser_printer t () =
+    List.iter (fun (name, str, _) ->
+        A.check A.string name str
+          (print_ofile (parse_ofile str)))
+      t
+
+  let positions () =
+    let filename = Sys.getcwd () ^ "/sample.opam" in
+    let content =
+      { file_contents =
+          [Variable ((filename, 1, 0), "int",
+                     Int ((filename, 1, 5), 0));
+           Variable ((filename, 2, 0),
+                     "string",
+                     String ((filename, 2, 8), "foo"));
+           Section
+             ((filename, 4, 0),
+              {section_kind = "section"; section_name = Some "thing";
+               section_items =
+                 [Variable ((filename, 5, 2), "url",
+                            String ((filename, 5, 7), "https://theinter.net"))
+                 ]
+              })
+          ];
+        file_name = filename}
+    in
+    A.check ofile_testable "sample" content (OpamParser.file filename)
+
+  let tests =
+    [
+      "parser", test_parser (opamfiles @ opamfiles_comment);
+      "printer", test_printer opamfiles;
+      "parser-printer", test_parser_printer opamfiles;
+      "positions-file", positions;
+    ]
+
+end
+
+let tests = [
+  "values", Value.tests;
+  "items", Item.tests;
+  "opamfile", Opamfile.tests;
+] |> List.map (fun (n,t) -> "oldpos "^n, t)

--- a/tests/utils.ml
+++ b/tests/utils.ml
@@ -8,12 +8,26 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module A = Alcotest
 
-let _ =
-  let tests =
-    Oldpos.tests @ Fullpos.tests
-    |> List.map (fun (n,t) ->
-        n, List.map (fun (n,t) -> n, `Quick, t) t)
-  in
-  A.run "opam-file-format" tests
+(* Common test functions *)
+
+let add_after_first ?(cond=fun _ -> true) c sep str =
+  try
+    let length = String.length str in
+    if not (cond str) then str else
+    let split = String.index str c in
+    let fst = String.sub str 0 (split+1) in
+    let snd = String.sub str (split+1) (length - split -1) in
+    fst ^ sep ^ snd
+  with _ -> failwith (Printf.sprintf "error with '%c' on %s" c str)
+
+let split_on_char sep s =
+  let r = ref [] in
+  let j = ref (String.length s) in
+  for i = String.length s - 1 downto 0 do
+    if String.get s i = sep then begin
+      r := String.sub s (i + 1) (!j - i - 1) :: !r;
+      j := i
+    end
+  done;
+  String.sub s 0 !j :: !r


### PR DESCRIPTION
Changes types of OpamParserTypes, to `foo_kind` the main type value and `foo` the type  with a position

```
type file_name = string
type pos =
  { filename: file_name;
    start: int * int; (* line, column *)
    stop: int * int; (* line, column *)
  }
type 'a with_pos =
  { pelem : 'a;
    pos : pos
  }
type value_kind =
  | Int of int
  [...]
and value = value_kind with_pos
```