### PR TITLE
No comment

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 2.1.2 [???]
 * Fix named section position [#31 @rjbou]
+* Add `OpamPrinter.FullPos.Preserved` functions to remove comments from an opamfile [#32 @rjbou]
 
 2.1.1 [17 Nov 2020]
 * New types with more complete positions [#24 @rjbou]

--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -804,7 +804,7 @@ module FullPos = struct
         str
         |> split_on_chars [ '\n'; '\r' ]
         |> List.map empty_end
-        |> List.filter (fun x -> x != "")
+        |> List.filter ((<>) "")
         |> String.concat "\n"
       in
       trim_end_whitespaces str

--- a/src/opamPrinter.mli
+++ b/src/opamPrinter.mli
@@ -112,6 +112,16 @@ module FullPos : sig
     (** [opamfile f] converts [f] to string, respecting the layout and comments in
         the corresponding on-disk file for unmodified items. [format_from] can be
         specified instead of using the filename specified in [f]. *)
+
+    val without_comments: ?filename:file_name -> string -> string
+    (** [without_comments ?filename content] removes all comment and trailing
+        newlines from the raw [content] of [filename]. [filename] is given as a
+        helper for opamfile parsing (errors). *)
+
+    val write_without_comments: from:file_name -> tout:file_name -> unit
+    (** [write_without_comments ~from ~tout] applies [without_comments] to [from]
+        file content and write it in [tout] file. *)
+
   end
 
   (** {2 Random utility functions} *)


### PR DESCRIPTION
Add `OpamPrinter.FullPos.without_comments` and its associate `OpamPrinter.FullPos.write_without_comment` that removes all comments from an opamfile, and trailing newlines.
cf. https://github.com/ocaml/opam/pull/4302#issuecomment-716634245

As it is low-level, It's implemented in `opam-file-format`, but it can be easily moved into `opam-format`.
To rebase after #31 merged