### PR TITLE
Fix build of implementation only opamParserTypes in Makefile build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,13 +21,13 @@ show:
 	ocamlyacc $<
 
 %.cmi: %.mli
-	ocamlc -c $(PP) $<
+	ocamlc -opaque -no-alias-deps -c $(PP) $<
 
 %.cmo: %.ml %.cmi
-	ocamlc -c $(PP) $<
+	ocamlc -opaque -no-alias-deps -c $(PP) $<
 
 %.cmx: %.ml %.cmi
-	ocamlopt -c $(PP) $<
+	ocamlopt -opaque -no-alias-deps -c $(PP) $<
 
 MODULES = $(sort $(basename $(wildcard *.ml *.mll *.mly)))
 


### PR DESCRIPTION
I had some issues linking against opam-file-format when it was built using the GNU make build process. I'm not sure if my solution is the best, but it has a pretty small diff and seems to work (I tested linking with building `opaline`).

[Having the make build process in place is kind of important for NixOS, since we'd otherwise run into circular dependencies since everything processing `.install` files depends on this library and we need to install it somehow which the `Makefile` nicely solves.]