### PR TITLE
OpamParserTypes is now a module

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 * Fix named section position [#31 @rjbou]
 * Don't include build system Flags module in installation [#34 @dra27]
 * Allow compilation with Dune 1.x [#35 @kit-ty-kate]
+* Fix compilation of OpamParserTypes [#36 @dra27]
 
 2.1.1 [17 Nov 2020]
 * New types with more complete positions [#24 @rjbou]

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LIBDIR ?= $(PREFIX)/lib
 install:
 	mkdir -p $(DESTDIR)$(LIBDIR)/opam-file-format
 	install -m 0644 \
-	  $(wildcard $(addprefix src/*.,cmi cmo cmx cmti lib a cma cmxa cmxs)) \
+	  $(wildcard $(addprefix src/*.,cmi cmo cmx cmt cmti lib a cma cmxa cmxs)) \
 	    src/META \
 	  $(DESTDIR)$(LIBDIR)/opam-file-format/
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,6 +17,8 @@ endif
 show:
 	echo $(OCAML_VERSION)
 
+opamParserTypes.cmi: opamParserTypes.cmo
+
 %.ml %.mli: %.mly
 	ocamlyacc $<
 

--- a/src/dune
+++ b/src/dune
@@ -4,8 +4,7 @@
   (synopsis "Parser and printer for the opam file syntax")
   (wrapped false)
   (modules :standard \ flags)
-  (flags :standard (:include flags.sexp))
-  (modules_without_implementation opamParserTypes))
+  (flags :standard (:include flags.sexp)))
 
 (rule
   (with-stdout-to flags.ml

--- a/src/opamParserTypes.ml
+++ b/src/opamParserTypes.ml
@@ -42,7 +42,7 @@ type env_update_op = Eq       (** [=] *)
                    | EqPlusEq (** [=+=] *)
 
 (** [OpamParserTypes] transitional module with full position types *)
-module FullPos : sig
+module FullPos = struct
 
   (** Source file positions *)
   type file_name = string


### PR DESCRIPTION
2.1.1 added `OpamParserTypes.FullPos`. Unfortunately, this means that `OpamParserTypes` is no longer an mli-only module. The `Makefile` build system attests this:

```
ocamlopt -c  opamParser.ml
File "_none_", line 1:
Warning 58: no cmx file was found in path for module OpamParserTypes, and its interface was not compiled with -opaque
```

and indeed we get link errors like this:
```
File "test_parser.ml", line 1:
Error: No implementations provided for the following modules:
         OpamParserTypes referenced from opam-file-format.cmxa(OpamParser)
```

Dune avoids this problem because `OpamParser` is compiled with `-no-alias-deps` which removes the link dependency on an implementation for `OpamParserTypes`. #36 essentially replicates this in the `Makefile`, but this still doesn't fix the underlying problem:

```ocaml
module F = OpamParserTypes.FullPos
```
which with both #36 and with Dune leads to:

```
dra27@summer:~/opam-file-format/src$ ocamlopt opam-file-format.cmxa -o broken broken.ml
File "broken.ml", line 1:
Error: No implementations provided for the following modules:
         OpamParserTypes referenced from broken.cmx
```

unless `broken.ml` itself is compiled with `-no-alias-deps`. Note that these modules have no business being compiled with `-no-alias-deps` (they don't really in Dune either) and compiling everything with `-opaque` kills cross-module inlining.

So this PR converts `OpamParserTypes.mli` to `OpamParserTypes.ml` which should fix the problem in both build systems.