### PR TITLE
Fix the Makefile-based build system (again)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+2.1.3 [???]
+* Fix module link order (broken by #37) [#41 @dra27]
+
 2.1.2 [07 Jan 2021]
 * Some hash-consing for strings [#27 @AltGr]
 * Fix named section position [#31 @rjbou]

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.0)
+(lang dune 1.3)

--- a/opam-file-format.opam
+++ b/opam-file-format.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "2.1.2"
+version: "2.1.3"
 synopsis: "Parser and printer for the opam file syntax"
 maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"

--- a/opam-file-format.opam
+++ b/opam-file-format.opam
@@ -20,3 +20,4 @@ depends: [
 depopts: [
   "dune"
 ]
+conflicts: "dune" {< "1.3.0"}

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,20 +31,20 @@ opamParserTypes.cmi: opamParserTypes.cmo
 %.cmx: %.ml
 	ocamlopt -c $(PP) $<
 
-MODULES = $(sort $(basename $(wildcard *.ml *.mll *.mly)))
+MODULES = opamParserTypes opamBaseParser opamLexer opamParser opamPrinter
 
 GENERATED = $(patsubst %.mly,%.ml,$(wildcard *.mly)) \
             $(patsubst %.mly,%.mli,$(wildcard *.mly)) \
             $(patsubst %.mll,%.ml,$(wildcard *.mll)) \
 	    META
 
-opam-file-format.cma: $(MODULES:%=%.cmo)
+opam-file-format.cma: $(addsuffix .cmo,$(MODULES))
 	ocamlc -a $^ -o $@
 
-opam-file-format.cmxa: $(MODULES:%=%.cmx)
+opam-file-format.cmxa: $(addsuffix .cmx,$(MODULES))
 	ocamlopt -a $^ -o $@
 
-opam-file-format.cmxs: $(MODULES:%=%.cmx)
+opam-file-format.cmxs: $(addsuffix .cmx,$(MODULES))
 	ocamlopt -shared $^ -o $@
 
 META: META.in ../opam-file-format.opam $(wildcard *.cm*)

--- a/tests/legacy/Makefile
+++ b/tests/legacy/Makefile
@@ -1,0 +1,11 @@
+.PHONY: test
+test: legacy.byte legacy.native
+
+src/%:
+	$(MAKE) -C src $*
+
+legacy.byte: src/opam-file-format.cma legacy.ml
+	ocamlc -o $@ -I src $^
+
+legacy.native: src/opam-file-format.cmxa legacy.ml
+	ocamlopt -o $@ -I src $^

--- a/tests/legacy/dune
+++ b/tests/legacy/dune
@@ -1,0 +1,8 @@
+; This test (driven by Dune) ensures that the old build system works
+
+(copy_files ../../opam-file-format.opam)
+
+(alias
+  (name runtest)
+  (deps Makefile legacy.ml opam-file-format.opam (glob_files src/*))
+  (action (run make test)))

--- a/tests/legacy/legacy.ml
+++ b/tests/legacy/legacy.ml
@@ -1,0 +1,3 @@
+(* This "program" is used to verify that the library is linkable - see #40 *)
+let file = OpamParser.FullPos.file "../opam-file-format.opam"
+in Printf.printf "Successfully loaded %s\n" file.OpamParserTypes.FullPos.file_name

--- a/tests/legacy/src/dune
+++ b/tests/legacy/src/dune
@@ -1,0 +1,3 @@
+; We mustn't copy the dune file, but Dune's globbing has no syntax for that
+(copy_files ../../../src/o*)
+(copy_files ../../../src/M*)


### PR DESCRIPTION
Adds a test for #40 and fixes it. The build system previously just put the modules in alphabetical order in the library which - flukily - worked, but doesn't since #37.