### PR TITLE
New internal variant for semantic versioning operator '~'

### DIFF
--- a/src/opamLexer.mll
+++ b/src/opamLexer.mll
@@ -27,7 +27,7 @@ let relop = function
   | ">"  -> `Gt
   | "<=" -> `Leq
   | "<"  -> `Lt
-  | "~"  -> `Geq
+  | "~"  -> `Sem
   | x    -> error "%S is not a valid comparison operator" x
 
 let logop = function

--- a/src/opamParserTypes.ml
+++ b/src/opamParserTypes.ml
@@ -20,6 +20,7 @@ type relop = [ `Eq  (** [=] *)
              | `Gt  (** [>] *)
              | `Leq (** [<=] *)
              | `Lt  (** [<] *)
+             | `Sem (** [~] *)
              ]
 
 (** Logical operators *)

--- a/tests/fullpos.ml
+++ b/tests/fullpos.ml
@@ -54,6 +54,7 @@ module Value = struct
     "greater-than",      ">",   `Gt;
     "lesser-or-equal",   "<=",  `Leq;
     "lesser-than",       "<",   `Lt;
+    "semver",            "~",   `Sem;
   ]
   let logop = [
     "disj",  "&",  `And;


### PR DESCRIPTION
This PR comes along with [another](https://github.com/ocaml/opam/pull/4532) to effectively add the semantic versioning operator to opam.