### PR TITLE
Require opam-version 2.1 and greater at the start of the file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
 2.1.3 [???]
 * Fix module link order (broken by #37) [#41 @dra27]
-* opam-version: "2.1" must appear at most once and as the first non-comment item [#43 @dra27]
+* opam-version: "2.1" must appear at most once and as the first non-comment
+  item. If opam-version is at the start and is greater than the library version,
+  `OpamLexer.Error` and `Parsing.Parse_error` are no longer raised; instead the
+  items parsed so far are returned. [#43 @dra27]
 
 2.1.2 [07 Jan 2021]
 * Some hash-consing for strings [#27 @AltGr]

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 2.1.3 [???]
 * Fix module link order (broken by #37) [#41 @dra27]
+* opam-version: "2.1" must appear at most once and as the first non-comment item [#43 @dra27]
 
 2.1.2 [07 Jan 2021]
 * Some hash-consing for strings [#27 @AltGr]

--- a/tests/hygiene/dune
+++ b/tests/hygiene/dune
@@ -1,0 +1,15 @@
+(copy_files ../../src/opamParserTypes.ml)
+
+(test
+  (name opamBaseParser)
+  (libraries opam-file-format)
+  (modules OpamParserTypes OpamBaseParser)
+  (action (run %{test} %{version:opam-file-format})))
+
+(ocamlyacc OpamBaseParser)
+
+(rule
+  (with-stdout-to OpamBaseParser.mly
+    (progn (cat ../../src/opamBaseParser.mly)
+           ; If this assertion fails, OpamBaseParser.version is wrong
+           (echo "let () = assert (Scanf.sscanf Sys.argv.(1) \"%u.%u\" (fun x y -> (x, y)) = version)"))))

--- a/tests/hygiene/dune
+++ b/tests/hygiene/dune
@@ -4,6 +4,7 @@
   (name opamBaseParser)
   (libraries opam-file-format)
   (modules OpamParserTypes OpamBaseParser)
+  (flags :standard (:include flags.sexp))
   (action (run %{test} %{version:opam-file-format})))
 
 (ocamlyacc OpamBaseParser)
@@ -13,3 +14,11 @@
     (progn (cat ../../src/opamBaseParser.mly)
            ; If this assertion fails, OpamBaseParser.version is wrong
            (echo "let () = assert (Scanf.sscanf Sys.argv.(1) \"%u.%u\" (fun x y -> (x, y)) = version)"))))
+
+(rule
+  (with-stdout-to flags.ml
+    (echo "print_string (if String.sub Sys.ocaml_version 0 5 = \"4.02.\" then \"(-w -50)\" else \"()\")")))
+
+(rule
+  (with-stdout-to flags.sexp
+    (run ocaml %{dep:flags.ml})))

--- a/tests/versions.ml
+++ b/tests/versions.ml
@@ -1,6 +1,6 @@
 (**************************************************************************)
 (*                                                                        *)
-(*    Copyright 2020 OCamlPro                                             *)
+(*    Copyright 2021 David Allsopp Ltd.                                   *)
 (*                                                                        *)
 (*  All rights reserved. This file is distributed under the terms of the  *)
 (*  GNU Lesser General Public License version 2.1, with the special       *)
@@ -10,10 +10,12 @@
 
 module A = Alcotest
 
-let _ =
-  let tests =
-    Oldpos.tests @ Fullpos.tests @ Versions.tests
-    |> List.map (fun (n,t) ->
-        n, List.map (fun (n,t) -> n, `Quick, t) t)
-  in
-  A.run "opam-file-format" tests
+let tests = [
+  (let n = "opam-version > 2.0 not at start 1" in
+   n, (fun () -> A.check_raises n Parsing.Parse_error (fun () -> OpamParser.FullPos.string "version: \"2.1\"\nopam-version: \"2.1\"" "broken.opam" |> ignore)));
+  (let n = "opam-version > 2.1 repeated" in
+   n, (fun () -> A.check_raises n Parsing.Parse_error (fun () -> OpamParser.FullPos.string "opam-version: \"2.1\"\nopam-version: \"2.1\"" "broken.opam" |> ignore)));
+]
+
+let tests =
+  ["opam-version", tests]


### PR DESCRIPTION
opam 2.1 does not define any new fields, so there is no need for any opam file to contain `opam-version: "2.1"`. Given this general quietness, there is one semantic change being made for the 2.1 and subsequent formats in order to allow the lexer and parser to evolve in future. `opam-version` must appear first (apart from whitespace and comments) for "2.1" and later, or the file does not parse. This gives the possibility in the future that additional constructs can be added to the file format, while retaining compatibility with older lexers.

This PR enforces two requirements on the whole-file lexing:

1. `opam-version: "2.1"` must be the first non-whitespace/comment field
2. For `opam-version: "2.1"` and greater, repeating the `opam-version` field is a parsing error

In both these cases, for maximum API compatibility, `Parsing.Parse_error` is raised rather than a new exception. API changes in the future will be needed to take advantage of this, but the key thing in this PR is to enforce the invariant so that this can be done when it's needed in future.

Opam itself only uses `OpamParser.FullPos.string`, `OpamParser.FullPos.channel`, `OpamParser.FullPos.main` all of which obey this. The only additional function used is `OpamParser.FullPos.value_from_string` - when lexing changes are introduced, functions such as that will need a parameter to specify the permitted lexing version.

On top of this, there is then an additional future-proofing change to the library: if `opam-version` is greater than the library version, then the lexer and parser do a best-effort parse. In this case, `Parse_error` is only raised if `opam-version` is not first (since it must be 2.2+) or if it is repeated _before_ the first lexer/parser error. This allows opam (and any other tool) to display a superior "this is an opam 2.2 file, so was ignored" rather than a lexer/parser error message which is more likely to result in users reporting bugs (to pinned repositories, opam-repository maintainers, etc.).

I added a few tests to ensure the `Parse_error` exceptions are raised. It could do with some more tests, although I have test_ed_ it! There is an additional slightly weird test which ensures that `OpamBaseParser.version` matches the build version.