### PR TITLE
Parsing future opam files take 2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,8 @@
 * opam-version: "2.1" must appear at most once and as the first non-comment
   item. If opam-version is at the start and is greater than the library version,
   `OpamLexer.Error` and `Parsing.Parse_error` are no longer raised; instead the
-  items parsed so far are returned. [#43 @dra27]
+  opam-version variable is returned along with an invalid group to signal the
+  parsing error, giving the client enough information to act. [#43, #44 @dra27]
 
 2.1.2 [07 Jan 2021]
 * Some hash-consing for strings [#27 @AltGr]

--- a/src/opamBaseParser.mly
+++ b/src/opamBaseParser.mly
@@ -172,6 +172,20 @@ let not_fatal = function
 | Match_failure _ -> false
 | _ -> true
 
+let get_three_tokens lexer lexbuf = 
+  let open Lexing in
+  try
+    let p0 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
+    let t1 = lexer lexbuf in
+    let p1 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
+    let t2 = lexer lexbuf in
+    let p2 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
+    let t3 = lexer lexbuf in
+    let p3 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
+    ((p0, p1, p2, p3), (t1, t2, t3))
+  with
+  | e when not_fatal e -> raise Parsing.Parse_error
+
 (* Wrap the ocamlyacc parser *)
 let main lexer lexbuf file_name =
   (* Extract the exceptions for opam-version not at the top of the file and
@@ -205,18 +219,7 @@ let main lexer lexbuf file_name =
   (* Now parse the header of the file manually. The smallest valid opam file
      is `ident: atom`, so if we can't read three tokens we have a parse error *)
   let ((((_, p0) as initial_pos), ((_, p1) as pos1), ((_, p2) as pos2), ((_, p3) as pos3)), (t1, t2, t3)) =
-    let open Lexing in
-    try
-      let p0 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
-      let t1 = lexer lexbuf in
-      let p1 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
-      let t2 = lexer lexbuf in
-      let p2 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
-      let t3 = lexer lexbuf in
-      let p3 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
-      ((p0, p1, p2, p3), (t1, t2, t3))
-    with
-    | e when not_fatal e -> raise Parsing.Parse_error
+    get_three_tokens lexer lexbuf
   in
   (* Parse those three tokens if they are [opam-version: ver] *)
   let (header, format_2_1_or_greater, trap_exceptions) =

--- a/src/opamBaseParser.mly
+++ b/src/opamBaseParser.mly
@@ -15,21 +15,17 @@ open OpamParserTypes.FullPos
 
 (** Opam config file generic type parser *)
 
-let get_pos_full ?(s=1) n =
-  let spos = Parsing.rhs_start_pos s in
-  let epos = Parsing.rhs_end_pos n in
+let pos_of_lexing_pos spos epos =
   Lexing.({
-      filename = spos.pos_fname;
-      start = spos.pos_lnum, spos.pos_cnum - spos.pos_bol;
-      stop = epos.pos_lnum, epos.pos_cnum - epos.pos_bol;
-    })
+    filename = spos.pos_fname;
+    start = spos.pos_lnum, spos.pos_cnum - spos.pos_bol;
+    stop = epos.pos_lnum, epos.pos_cnum - epos.pos_bol;
+  })
+
+let get_pos_full ?(s=1) n =
+  pos_of_lexing_pos (Parsing.rhs_start_pos s) (Parsing.rhs_end_pos n)
 
 let get_pos n = get_pos_full ~s:n n
-
-let parsed_so_far = ref []
-
-let record_token t =
-  parsed_so_far := t :: !parsed_so_far; t
 
 (* This must match up with the package's version; checked by the build system *)
 let version = (2, 1)
@@ -69,7 +65,7 @@ let version = (2, 1)
 %%
 
 main:
-| items EOF { parsed_so_far := []; fun file_name ->
+| items EOF { fun file_name ->
         { file_contents = $1; file_name } }
 ;
 
@@ -80,14 +76,12 @@ items:
 
 item:
 | IDENT COLON value                {
-  record_token
   { pos = get_pos_full 3;
     pelem =
       Variable ({ pos = get_pos 1; pelem =  $1 }, $3);
   }
 }
 | IDENT LBRACE items RBRACE {
-  record_token
   { pos = get_pos_full 4;
     pelem =
       Section ({section_kind = { pos = get_pos 1; pelem = $1 };
@@ -98,7 +92,6 @@ item:
   }
 }
 | IDENT STRING LBRACE items RBRACE {
-  record_token
   { pos = get_pos_full 4;
     pelem =
       Section ({section_kind = { pos = get_pos 1; pelem = $1 };
@@ -165,84 +158,131 @@ let with_clear_parser f x =
     Parsing.clear_parser ();
     raise e
 
-exception Nothing
-
-let reset_lexbuf l file_name (start_line, start_col) (end_line, end_col) =
+(* Update a lexbuf with position information prior to raising an exception *)
+let reset_lexbuf_and_abort l file_name (start_line, start_col) (end_line, end_col) exn =
   let open Lexing in
   l.lex_start_p <- {pos_fname = file_name; pos_lnum = start_line; pos_bol = 0; pos_cnum = start_col};
   l.lex_curr_p <- {pos_fname = file_name; pos_lnum = end_line; pos_bol = 0; pos_cnum = end_col};
-  true
+  exn ()
 
-let main t l file_name =
-  (* Always return a result from parsing/lexing, but note if an exception
-     occurred. *)
-  let parsing_exception = ref Lexing.(Nothing, dummy_pos, dummy_pos) in
-  let raise_if_parsing_failed = function
-  | false -> ()
-  | true ->
-      match parsing_exception with
-      | {contents = (Nothing, _, _)} -> ()
-      | {contents = (e, start, curr)} ->
-          let open Lexing in
-          l.lex_start_p <- start;
-          l.lex_curr_p <- curr;
-          raise e
+(* cf. OpamStd.fatal - always allow standard exceptions to propagate. *)
+let not_fatal = function
+| Sys.Break
+| Assert_failure _
+| Match_failure _ -> false
+| _ -> true
+
+(* Wrap the ocamlyacc parser *)
+let main lexer lexbuf file_name =
+  (* Extract the exceptions for opam-version not at the top of the file and
+     opam-version duplicated. OpamLexer has special cases for these two
+     constants. If OpamLexer.token isn't used, raise Parse_error instead. *)
+  let exn_not_first () =
+    let _ = lexer (Lexing.from_string "version: \"42\"\nopam-version: \"2.1\"") in
+    raise Parsing.Parse_error
+  and exn_duplicate () =
+    let _ = lexer (Lexing.from_string "opam-version: \"2.1\"\nopam-version: \"z\"") in
+    raise Parsing.Parse_error
+  and restore_pos (start, curr) =
+    let open Lexing in
+    lexbuf.lex_start_p <- start;
+    lexbuf.lex_curr_p <- curr
   in
-  let t l =
-    try t l
+  (* Raises the exn_not_first or exn_duplicate exceptions if an invalid
+     opam-version variable is found in the result. *)
+  let scan_opam_version_variable format_2_1_or_greater = function
+  | {pelem = Variable({pelem = "opam-version"; _}, {pelem = String ver; _}); pos = {start; stop; _}} ->
+      if format_2_1_or_greater then
+        (* [opam-version] can only appear once for 2.1+ *)
+        reset_lexbuf_and_abort lexbuf file_name start stop exn_duplicate
+      else if nopatch ver > (2, 0) then
+        (* Only [opam-version: "2.0"] can appear after the first non-comment/whitespace line of the file *)
+        reset_lexbuf_and_abort lexbuf file_name start stop exn_not_first
+      else
+        ()
+  | _ -> ()
+  in
+  (* Now parse the header of the file manually. The smallest valid opam file
+     is `ident: atom`, so if we can't read three tokens we have a parse error *)
+  let ((((_, p0) as initial_pos), ((_, p1) as pos1), ((_, p2) as pos2), ((_, p3) as pos3)), (t1, t2, t3)) =
+    let open Lexing in
+    try
+      let p0 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
+      let t1 = lexer lexbuf in
+      let p1 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
+      let t2 = lexer lexbuf in
+      let p2 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
+      let t3 = lexer lexbuf in
+      let p3 = lexbuf.lex_start_p, lexbuf.lex_curr_p in
+      ((p0, p1, p2, p3), (t1, t2, t3))
     with
-    | Sys.Break
-    | Assert_failure _
-    | Match_failure _ as e -> raise e
-    | e -> parsing_exception := Lexing.(e, l.lex_start_p, l.lex_curr_p); EOF
+    | e when not_fatal e -> raise Parsing.Parse_error
   in
-    let r =
-      try with_clear_parser (main t l) file_name
-      with Parsing.Parse_error as e ->
-        parsing_exception := Lexing.(e, l.lex_start_p, l.lex_curr_p);
-        (* Record the tokens captured so far *)
-        let r = {file_contents = List.rev !parsed_so_far; file_name} in
-        parsed_so_far := [];
-        r
-    in
-    match r with
-    | {file_contents = {pelem = Variable({pelem = "opam-version"; _}, {pelem = String ver; _}); _}::items; _}
-      when nopatch ver >= (2, 1) ->
-        let opam_version_variable = function
-        | {pelem = Variable({pelem = "opam-version"; _}, _); pos = {start; stop; _}} ->
-            reset_lexbuf l file_name start stop
-        | _ -> false
+  (* Parse those three tokens if they are [opam-version: ver] *)
+  let (header, format_2_1_or_greater, trap_exceptions) =
+    match (t1, t2, t3) with
+    | (IDENT "opam-version", COLON, STRING ver) ->
+        let header =
+          (* Parsing or lexing errors immediate following opam-version may cause
+             an exception to be raised before the element has been fully parsed.
+             In this case, we generate a single opam-version Variable to return.
+           *)
+          {pelem = Variable({pelem = "opam-version"; pos = pos_of_lexing_pos p0 p1},
+                             {pelem = String ver; pos = pos_of_lexing_pos p2 p3});
+           pos = pos_of_lexing_pos p0 p3}
         in
-          (* For opam-version: 2.1 and later, there must be no other opam-version
-             fields. *)
-          if List.exists opam_version_variable items then
-            raise Parsing.Parse_error;
-          (* Parsing and lexing errors from future versions of opam are ignored:
-             the intent is that the tool will abort/ignore because of the
-             opam-version field rather than through lexer/parser errors. *)
-          raise_if_parsing_failed (nopatch ver <= version);
-          r
-    | {file_contents = items; _} ->
-        let opam_version_greater_2_0 = function
-        | {pelem = Variable({pelem = "opam-version"; _}, {pelem = String ver; _}); pos = {start; stop; _}}
-          when nopatch ver > (2, 0) ->
-            reset_lexbuf l file_name start stop
-        | _ -> false
+        (header, (nopatch ver >= (2, 1)), (nopatch ver > version))
+    | _ ->
+        (* Default is [opam-version: "2.0"] *)
+        let pos = {filename = ""; start = (0, 0); stop = (0, 0)} in
+        ({pelem = Variable ({pelem = ""; pos}, {pelem = Int 42; pos}); pos}, false, false)
+  in
+  (* The parser will use position information from the lexbuf, so replay the
+     positions, even if we're not actually reading anything. *)
+  restore_pos initial_pos;
+  (* Wrap the lexer to simulate reading those three tokens a second time *)
+  let lexer =
+    let tokens = ref [t1, pos1; t2, pos2; t3, pos3] in
+    fun lexbuf ->
+      match tokens with
+      | {contents = (t, p)::rest} ->
+          tokens := rest;
+          restore_pos p;
+          t
+      | {contents = []} ->
+          lexer lexbuf
+  in
+  let result =
+    try with_clear_parser (main lexer lexbuf) file_name
+    with e when trap_exceptions && not_fatal e ->
+      (* Append a syntactically invalid sentinel section "#" to the version
+         header which was manually parsed. That is then sufficient
+         information for a client to determine that the file was invalid.
+         If OpamBaseParser.version = (2, 1), this would allow
+         `opam-version: "2.2"`, containing no lexer or parser changes, still to
+         report syntax errors in opam 2.2, by using this sentinel group to
+         detect the parsing error. *)
+      let sentinel =
+        let pos =
+          Lexing.(pos_of_lexing_pos lexbuf.lex_start_p lexbuf.lex_curr_p)
         in
-          (* opam-version: 2.1 or later must be the first item. *)
-          if List.exists opam_version_greater_2_0 items then
-            raise Parsing.Parse_error;
-          (* If no opam-version field was given, all exceptions must be
-             raised. *)
-          raise_if_parsing_failed true;
-          r
+        let section =
+          {section_kind = {pelem = "#"; pos};
+           section_name = None;
+           section_items = {pelem = []; pos}}
+        in
+          {pelem = Section section; pos}
+      in
+      {file_contents = [header; sentinel]; file_name}
+  in
+  begin
+    match result with
+    | {file_contents = _::items; _} ->
+        (* Ensure that there are no `opam-version` fields with a value >= "2.1"
+           further down the file. *)
+        List.iter (scan_opam_version_variable format_2_1_or_greater) items
+    | _ -> ()
+  end;
+  result
 
-let value t l =
-  try
-    let r = value t l in
-    Parsing.clear_parser ();
-    r
-  with
-  | e ->
-    Parsing.clear_parser ();
-    raise e
+let value t l = with_clear_parser (value t) l

--- a/src/opamLexer.mll
+++ b/src/opamLexer.mll
@@ -138,6 +138,13 @@ rule token = parse
 | pfxop  { PFXOP (FullPos.pfxop (Lexing.lexeme lexbuf)) }
 | envop  { ENVOP (FullPos.env_update_op (Lexing.lexeme lexbuf)) }
 | eof    { EOF }
+(* OpamBaseParser can't directly access OpamLexer.Error so it uses these
+   constants (which would parse that way) to extract the exception values.
+ *)
+| "opam-version: \"2.1\"\nopam-version: \"z\"" eof
+         { error "opam-version cannot be repeated" }
+| "version: \"42\"\nopam-version: \"2.1\"" eof
+         { error "opam-version must be the first non-comment line" }
 | _      { let token = Lexing.lexeme lexbuf in
            error "'%s' is not a valid token" token }
 

--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -222,7 +222,31 @@ module Normalise = struct
          | None -> "")
         (String.concat "\n" (List.map item s.section_items))
 
+  (* The code duplication with OpamBaseParser is irritating, but can't be solved
+     without introducing another module. *)
+  let nopatch v =
+    let s =
+    try
+      let i = String.index v '.' in
+      let i = String.index_from v (i+1) '.' in
+      (String.sub v 0 i)
+    with Not_found ->
+      let rec f i =
+        if i >= String.length v then v
+        else match String.get v i with
+          | '0'..'9' | '.' -> f (i+1)
+          | _ -> String.sub v 0 i
+      in
+      f 0
+    in
+      try Scanf.sscanf s "%u.%u" (fun maj min -> (maj, min))
+      with Scanf.Scan_failure _ -> (0, 0)
+
   let item_order a b = match a,b with
+    | Variable (_, "opam-version", String (_, ver)), _
+      when nopatch ver >= (2, 1) -> -1
+    | _, Variable (_, "opam-version", String (_, ver))
+      when nopatch ver >= (2, 1) -> 1
     | Section _, Variable _ -> 1
     | Variable _, Section _ -> -1
     | Variable (_,i,_), Variable (_,j,_) -> String.compare i j
@@ -546,32 +570,12 @@ module FullPos = struct
            | None -> "")
           (String.concat "\n" (List.map item s.section_items.pelem))
 
-    (* The code duplication with OpamBaseParser is irritating, but can't be solved
-       without introducing another module. *)
-    let nopatch v =
-      let s =
-      try
-        let i = String.index v '.' in
-        let i = String.index_from v (i+1) '.' in
-        (String.sub v 0 i)
-      with Not_found ->
-        let rec f i =
-          if i >= String.length v then v
-          else match String.get v i with
-            | '0'..'9' | '.' -> f (i+1)
-            | _ -> String.sub v 0 i
-        in
-        f 0
-      in
-        try Scanf.sscanf s "%u.%u" (fun maj min -> (maj, min))
-        with Scanf.Scan_failure _ -> (0, 0)
-
     let item_order a b =
       match a.pelem ,b.pelem with
       | Variable ({pelem = "opam-version"; _}, {pelem = String ver; _}), _
-        when nopatch ver >= (2, 1) -> -1
+        when Normalise.nopatch ver >= (2, 1) -> -1
       | _, Variable ({pelem = "opam-version"; _}, {pelem = String ver; _})
-        when nopatch ver >= (2, 1) -> 1
+        when Normalise.nopatch ver >= (2, 1) -> 1
       | Section _, Variable _ -> 1
       | Variable _, Section _ -> -1
       | Variable (i,_), Variable (j,_) -> String.compare i.pelem j.pelem

--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -11,6 +11,43 @@
 
 open OpamParserTypes
 
+(* The code duplication with OpamBaseParser is irritating, but can't be solved
+   without introducing another module. *)
+let nopatch v =
+  let s =
+  try
+    let i = String.index v '.' in
+    let i = String.index_from v (i+1) '.' in
+    (String.sub v 0 i)
+  with Not_found ->
+    let rec f i =
+      if i >= String.length v then v
+      else match String.get v i with
+        | '0'..'9' | '.' -> f (i+1)
+        | _ -> String.sub v 0 i
+    in
+    f 0
+  in
+    try Scanf.sscanf s "%u.%u" (fun maj min -> (maj, min))
+    with Scanf.Scan_failure _ -> (0, 0)
+
+let valid_opamfile_contents = function
+| (Variable (_, "opam-version", String (_, ver)))::items
+    when nopatch ver >= (2, 1) ->
+      let opam_version_field = function
+      | Variable (_, "opam-version", _) -> true
+      | _ -> false
+      in
+        not (List.exists opam_version_field items)
+| _::items ->
+    let greater_2_0_opam_version_field = function
+    | Variable (_, "opam-version", String (_, ver))
+       when nopatch ver >= (2, 1) -> true
+    | _ -> false
+    in
+      not (List.exists greater_2_0_opam_version_field items)
+| [] -> true
+
 let relop = function
   | `Eq  -> "="
   | `Neq -> "!="
@@ -134,6 +171,8 @@ let format_opamfile fmt f =
   Format.pp_print_newline fmt ()
 
 let items l =
+  if not (valid_opamfile_contents l) then
+    invalid_arg "OpamPrinter.items";
   format_items Format.str_formatter l; Format.flush_str_formatter ()
 
 let opamfile f =
@@ -222,26 +261,6 @@ module Normalise = struct
          | None -> "")
         (String.concat "\n" (List.map item s.section_items))
 
-  (* The code duplication with OpamBaseParser is irritating, but can't be solved
-     without introducing another module. *)
-  let nopatch v =
-    let s =
-    try
-      let i = String.index v '.' in
-      let i = String.index_from v (i+1) '.' in
-      (String.sub v 0 i)
-    with Not_found ->
-      let rec f i =
-        if i >= String.length v then v
-        else match String.get v i with
-          | '0'..'9' | '.' -> f (i+1)
-          | _ -> String.sub v 0 i
-      in
-      f 0
-    in
-      try Scanf.sscanf s "%u.%u" (fun maj min -> (maj, min))
-      with Scanf.Scan_failure _ -> (0, 0)
-
   let item_order a b = match a,b with
     | Variable (_, "opam-version", String (_, ver)), _
       when nopatch ver >= (2, 1) -> -1
@@ -256,6 +275,8 @@ module Normalise = struct
       else compare s.section_name t.section_name
 
   let items its =
+    if not (valid_opamfile_contents its) then
+      invalid_arg "OpamPrinter.Normalise.items";
     let its = List.sort item_order its in
     String.concat "\n" (List.map item its) ^ "\n"
 
@@ -264,6 +285,8 @@ end
 
 module Preserved = struct
   let items txt orig f =
+    if not (valid_opamfile_contents f) then
+      invalid_arg "OpamPrinter.Preserved.items";
     let pos_index =
       let lines_index =
         let rec aux acc s =
@@ -352,6 +375,23 @@ end
 module FullPos = struct
 
   open OpamParserTypes.FullPos
+
+  let valid_opamfile_contents = function
+  | {pelem = Variable ({pelem = "opam-version"; _}, {pelem = String ver; _}); _}::items
+      when nopatch ver >= (2, 1) ->
+        let opam_version_field = function
+        | {pelem = Variable ({pelem = "opam-version"; _}, _); _} -> true
+        | _ -> false
+        in
+          not (List.exists opam_version_field items)
+  | _::items ->
+      let greater_2_0_opam_version_field = function
+      | {pelem = Variable ({pelem = "opam-version"; _}, {pelem = String ver; _}); _}
+         when nopatch ver >= (2, 1) -> true
+      | _ -> false
+      in
+        not (List.exists greater_2_0_opam_version_field items)
+  | [] -> true
 
   let relop_kind = relop
   let relop r = relop_kind r.pelem
@@ -457,6 +497,8 @@ module FullPos = struct
     Format.pp_print_newline fmt ()
 
   let items l =
+    if not (valid_opamfile_contents l) then
+      invalid_arg "OpamPrinter.FullPos.items";
     format_items Format.str_formatter l; Format.flush_str_formatter ()
 
   let opamfile f =
@@ -573,9 +615,9 @@ module FullPos = struct
     let item_order a b =
       match a.pelem ,b.pelem with
       | Variable ({pelem = "opam-version"; _}, {pelem = String ver; _}), _
-        when Normalise.nopatch ver >= (2, 1) -> -1
+        when nopatch ver >= (2, 1) -> -1
       | _, Variable ({pelem = "opam-version"; _}, {pelem = String ver; _})
-        when Normalise.nopatch ver >= (2, 1) -> 1
+        when nopatch ver >= (2, 1) -> 1
       | Section _, Variable _ -> 1
       | Variable _, Section _ -> -1
       | Variable (i,_), Variable (j,_) -> String.compare i.pelem j.pelem
@@ -585,6 +627,8 @@ module FullPos = struct
         else compare s.section_name t.section_name
 
     let items its =
+      if not (valid_opamfile_contents its) then
+        invalid_arg "OpamPrinter.Normalise.items";
       let its = List.sort item_order its in
       String.concat "\n" (List.map item its) ^ "\n"
 
@@ -593,6 +637,8 @@ module FullPos = struct
 
   module Preserved = struct
     let items txt orig f =
+      if not (valid_opamfile_contents f) then
+        invalid_arg "OpamPrinter.Preserved.items";
       let pos_index =
         let lines_index =
           let rec aux acc s =

--- a/src/opamPrinter.mli
+++ b/src/opamPrinter.mli
@@ -61,16 +61,26 @@ module FullPos : sig
       newlines}. *)
 
   val items: opamfile_item list -> string
+  (** Converts a list of opam field/sections to a string.
+
+      @raise Invalid_argument if ["opam-version"] is greater than "2.0"
+                              and not solely the first item. *)
 
   val opamfile: opamfile -> string
-  (** Converts an {!opamfile} to a string. *)
+  (** Converts an {!opamfile} to a string.
+
+      @raise Invalid_argument if ["opam-version"] is greater than "2.0"
+                              and not solely the first item. *)
 
   val format_opamfile: Format.formatter -> opamfile -> unit
   (** Writes an {!opamfile} to a [Format.formatter]. The function ensures that all
       newlines are sent using [Format]'s break instructions (and so ultimately are
       processed with the [out_newline] function of the formatter) but it is the
       responsibility of the caller to ensure that the formatter is configured for
-      the required output, if necessary. *)
+      the required output, if necessary.
+
+      @raise Invalid_argument if ["opam-version"] is greater than "2.0"
+                              and not solely the first item. *)
 
   (** {2 Normalised output for opam syntax files} *)
 
@@ -106,12 +116,20 @@ module FullPos : sig
     (** [items str orig_its its] converts [its] to string, while attempting to
         preserve the layout and comments of the original [str] for unmodified
         elements. The function assumes that [str] parses to the items
-        [orig_its]. *)
+        [orig_its].
+
+        @raise Invalid_argument if ["opam-version"] is greater than "2.0"
+                                and not solely the first item in either list. *)
 
     val opamfile: ?format_from:file_name -> opamfile -> string
     (** [opamfile f] converts [f] to string, respecting the layout and comments in
         the corresponding on-disk file for unmodified items. [format_from] can be
-        specified instead of using the filename specified in [f]. *)
+        specified instead of using the filename specified in [f].
+
+        @raise Invalid_argument if ["opam-version"] is greater than "2.0"
+                                and not solely the first item in the list. Note that
+                                any errors in the file raise {!OpamLexer.Error} as
+                                normal. *)
   end
 
   (** {2 Random utility functions} *)

--- a/tests/versions.ml
+++ b/tests/versions.ml
@@ -11,40 +11,73 @@
 module A = Alcotest
 
 let tests_exn = [
-  "opam-version > 2.0 not at start 1",
+  "opam-version > 2.0 not at start 1", OpamLexer.Error("opam-version must be the first non-comment line"),
   {|
 version: "2.1"
 opam-version: "2.1"
   |};
-  "opam-version > 2.1 repeated",
+  "opam-version > 2.1 repeated", OpamLexer.Error("opam-version cannot be repeated"),
   {|
 opam-version: "2.1"
 opam-version: "2.1"
   |};
-  "no opam-version and parsing error",
+  "no opam-version and parsing error", Parsing.Parse_error,
   {|
 build: [ "echo"
   |};
-  "opam-version 2.1 and parsing error",
+  "opam-version 2.1 and lexing error", OpamLexer.Error "'@' is not a valid token",
+  {|
+opam-version: "2.1"
+@
+  |};
+  "opam-version 2.1 and parsing error", Parsing.Parse_error,
   {|
 opam-version: "2.1"
 build: [ "echo"
   |};
-] |> List.map (fun (name, content) ->
+  "opam-version 2.1 and immediate parsing error", Parsing.Parse_error,
+  {|
+opam-version: "2.1"
+!!
+  |};
+] |> List.map (fun (name, exn, content) ->
     name, (fun () ->
-        A.check_raises name Parsing.Parse_error (fun () ->
+        A.check_raises name exn (fun () ->
             OpamParser.FullPos.string content "broken.opam" |> ignore)))
 
+let has_sentinel =
+  let open OpamParserTypes.FullPos in
+  fun {file_contents; _} ->
+    match List.rev file_contents with
+    | {pelem = Section {section_kind = {pelem = "#"; _}; _}; _}::_ -> true
+    | _ -> false
+
 let tests_noexn = [
-  "opam-version 2.2 and parsing error",
+  "opam-version 42.0 and parsing error",
   {|
-opam-version: "2.2"
-build: [ "echo"
+opam-version: "42.0"
+version: "42.0"
+!!
+  |};
+  "opam-version 42.0 and evil parsing error",
+  {|
+opam-version: "42.0" <
+  |};
+  "opam-version 42.0 and immediate parsing error",
+  {|
+opam-version: "42.0"
+!!
+  |};
+  "opam-version 42.0 and lexing error",
+  {|
+opam-version: "42.0"
+@
   |};
 ] |> List.map (fun (name, content) ->
     name, (fun () ->
-        A.check A.unit name ()
-          (OpamParser.FullPos.string content "broken.opam" |> ignore)))
+        A.check A.bool name true
+          (OpamParser.FullPos.string content "broken.opam"
+           |> has_sentinel)))
 
 let tests =
   ["opam-version", tests_exn @ tests_noexn]


### PR DESCRIPTION
This is complete reimplementation of #43 with the following changes:

The first attempt couldn't cope with, say, `opam-version: "42" <` because the parsing error occurs before the `Variable` has been completely parsed. This revised version instead reads three tokens from the lexer and so "sniff" the `opam-version` before parsing starts. With this approach, there's no need to do all of the global state mucking around - we already know if the opam file is a "future" one and so any exception can instead just return the `opam-version` line we successfully parsed. In order to allow a future version of opam to intentionally stick with an old parser (e.g. because opam 2.2 adds no new lexing/parsing rules), as well as the `opam-version` item, a sentinel section of kind `#` is returned which opam can then use to determine that there was actually a parse error.

Finally, I thought of a devious, yet curiously actually valid, way of raising `OpamLexer.Error` from `OpamBaseParser.main` which means that `opam-version` in the wrong place now includes a description of the problem rather than just "parse error".