### PR TITLE
Use Scanf correctly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@
   item. If opam-version is at the start and is greater than the library version,
   `OpamLexer.Error` and `Parsing.Parse_error` are no longer raised; instead the
   opam-version variable is returned along with an invalid group to signal the
-  parsing error, giving the client enough information to act. [#43, #44 @dra27]
+  parsing error, giving the client enough information to act.
+  [#43, #44, #45 @dra27]
 
 2.1.2 [07 Jan 2021]
 * Some hash-consing for strings [#27 @AltGr]

--- a/src/opamBaseParser.mly
+++ b/src/opamBaseParser.mly
@@ -146,8 +146,14 @@ let nopatch v =
     in
     f 0
   in
-    try Scanf.sscanf s "%u.%u" (fun maj min -> (maj, min))
-    with Scanf.Scan_failure _ -> (0, 0)
+    try Scanf.sscanf s "%u.%u%!" (fun maj min -> (maj, min))
+    with Scanf.Scan_failure _
+       | Failure _
+       | End_of_file ->
+           try Scanf.sscanf s "%u%!" (fun maj -> (maj, 0))
+           with Scanf.Scan_failure _
+              | Failure _
+              | End_of_file -> (0, 0)
 
 let with_clear_parser f x =
   try

--- a/src/opamPrinter.ml
+++ b/src/opamPrinter.ml
@@ -28,8 +28,14 @@ let nopatch v =
     in
     f 0
   in
-    try Scanf.sscanf s "%u.%u" (fun maj min -> (maj, min))
-    with Scanf.Scan_failure _ -> (0, 0)
+    try Scanf.sscanf s "%u.%u%!" (fun maj min -> (maj, min))
+    with Scanf.Scan_failure _
+       | Failure _
+       | End_of_file ->
+           try Scanf.sscanf s "%u%!" (fun maj -> (maj, 0))
+           with Scanf.Scan_failure _
+              | Failure _
+              | End_of_file -> (0, 0)
 
 let valid_opamfile_contents = function
 | (Variable (_, "opam-version", String (_, ver)))::items

--- a/tests/versions.ml
+++ b/tests/versions.ml
@@ -72,6 +72,11 @@ let has_sentinel =
     | _ -> false
 
 let tests_noexn = [
+  "opam-version 4 and parsing error",
+  {|
+opam-version: "4"
+!!
+  |};
   "opam-version 42.0 and parsing error",
   {|
 opam-version: "42.0"


### PR DESCRIPTION
The nopatch function wasn't handling all the possible error cases from `Sscanf.scanf` - it also wouldn't have correctly treated `opam-version: "5"` as being equivalent to `opam-version: "5.0"`