### PR TITLE
Hygiene tests: don't duplicate compilation units

### DIFF
--- a/tests/hygiene/dune
+++ b/tests/hygiene/dune
@@ -1,14 +1,15 @@
+(copy_files ../../src/opamParserTypes.ml)
+
 (test
-  (name opamBaseParserForTest)
-  (libraries opam-file-format)
-  (modules OpamBaseParserForTest)
+  (name opamBaseParser)
+  (modules OpamParserTypes OpamBaseParser)
   (flags :standard (:include flags.sexp))
   (action (run %{test} %{version:opam-file-format})))
 
-(ocamlyacc OpamBaseParserForTest)
+(ocamlyacc OpamBaseParser)
 
 (rule
-  (with-stdout-to OpamBaseParserForTest.mly
+  (with-stdout-to OpamBaseParser.mly
     (progn (cat ../../src/opamBaseParser.mly)
            ; If this assertion fails, OpamBaseParser.version is wrong
            (echo "let () = assert (Scanf.sscanf Sys.argv.(1) \"%u.%u\" (fun x y -> (x, y)) = version)"))))

--- a/tests/hygiene/dune
+++ b/tests/hygiene/dune
@@ -1,16 +1,14 @@
-(copy_files ../../src/opamParserTypes.ml)
-
 (test
-  (name opamBaseParser)
+  (name opamBaseParserForTest)
   (libraries opam-file-format)
-  (modules OpamParserTypes OpamBaseParser)
+  (modules OpamBaseParserForTest)
   (flags :standard (:include flags.sexp))
   (action (run %{test} %{version:opam-file-format})))
 
-(ocamlyacc OpamBaseParser)
+(ocamlyacc OpamBaseParserForTest)
 
 (rule
-  (with-stdout-to OpamBaseParser.mly
+  (with-stdout-to OpamBaseParserForTest.mly
     (progn (cat ../../src/opamBaseParser.mly)
            ; If this assertion fails, OpamBaseParser.version is wrong
            (echo "let () = assert (Scanf.sscanf Sys.argv.(1) \"%u.%u\" (fun x y -> (x, y)) = version)"))))


### PR DESCRIPTION
This test added in #43 creates a binary with conflicting compilation units. In particular, `OpamBaseParser` is both present in the `opamFileFormat` library and on the command line, and it is only by sheer luck that the compiler manages to not complain about that (Flambda 2 does actually complain about that).

My proposed fix is to use a different name, but my reading of the `dune` file also suggests that maybe linking with the library wasn't intended.

We're going to have to patch Flambda 2 anyway, as the same problems arise in more complicated situations, but I think this PR is a good improvement on its own.