### PR TITLE
change kprintf -> ksprintf

### DIFF
--- a/src/opamLexer.mll
+++ b/src/opamLexer.mll
@@ -18,7 +18,7 @@ exception Error of string
 
 let newline lexbuf = Lexing.new_line lexbuf
 let error fmt =
-  Printf.kprintf (fun msg -> raise (Error msg)) fmt
+  Printf.ksprintf (fun msg -> raise (Error msg)) fmt
 
 let relop = function
   | "="  -> `Eq


### PR DESCRIPTION
`kprintf` has been deprecated for `ksprintf` for some time now.

We get warnings in OCaml 5.0 since we vendor these repos in Dune.

ping @dra27 @kit-ty-kate 

