### PR TITLE
Make the library domain-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # opam-file-format - Parser and printer for the opam file syntax
 
 This library provides the parser and printer for the opam file syntax as a
-library with no dependencies but [Dune](https://dune.build) >= 1.4.
+library with no dependencies but [Dune](https://dune.build) >= 2.0.
 
 Opam was created and is maintained by [OCamlPro](http://www.ocamlpro.com).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # opam-file-format - Parser and printer for the opam file syntax
 
 This library provides the parser and printer for the opam file syntax as a
-library with no dependencies but [Dune](https://dune.build) >= 2.0.
+library with no dependencies but [Dune](https://dune.build) >= 3.13.
 
 Opam was created and is maintained by [OCamlPro](http://www.ocamlpro.com).
 

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 2.0)
+(lang dune 3.13)
 (using menhir 2.0)

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
-(lang dune 1.4)
+(lang dune 2.0)
+(using menhir 2.0)

--- a/opam-file-format.opam
+++ b/opam-file-format.opam
@@ -11,7 +11,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02"}
-  "dune" {>= "2.0"}
+  "dune" {>= "3.13"}
   "menhir" {>= "20211230"}
   "alcotest" {with-test & >= "0.4.8"}
   "fmt" {with-test}

--- a/opam-file-format.opam
+++ b/opam-file-format.opam
@@ -10,8 +10,9 @@ dev-repo: "git+https://github.com/ocaml/opam-file-format"
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 depends: [
-  "ocaml"
-  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.02"}
+  "dune" {>= "2.0"}
+  "menhir" {>= "20211230"}
   "alcotest" {with-test & >= "0.4.8"}
   "fmt" {with-test}
 ]

--- a/src/compat/domain.ml
+++ b/src/compat/domain.ml
@@ -1,0 +1,4 @@
+module DLS = struct
+  let new_key f = f ()
+  let get x = x
+end

--- a/src/compat/dune
+++ b/src/compat/dune
@@ -1,0 +1,6 @@
+(rule
+ (enabled_if (< %{ocaml_version} "5.0"))
+ (action (with-stdout-to compat.sexp (echo "(\"domain\")"))))
+(rule
+ (enabled_if (>= %{ocaml_version} "5.0"))
+ (action (with-stdout-to compat.sexp (echo "()"))))

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,12 @@
   (public_name opam-file-format)
   (synopsis "Parser and printer for the opam file syntax")
   (wrapped false)
+  (private_modules (:include compat/compat.sexp))
   (flags :standard (:include flags.sexp)))
+
+(rule
+ (enabled_if (< %{ocaml_version} "5.0"))
+ (action (copy compat/domain.ml domain.ml)))
 
 (rule
  (enabled_if (< %{ocaml_version} "4.03"))

--- a/src/dune
+++ b/src/dune
@@ -12,7 +12,7 @@
  (enabled_if (>= %{ocaml_version} "4.03"))
  (action (with-stdout-to flags.sexp (echo "()"))))
 
-(ocamlyacc opamBaseParser)
+(menhir (modules opamBaseParser) (infer false))
 (ocamllex opamLexer)
 
 (env (dev

--- a/src/opamBaseParser.mly
+++ b/src/opamBaseParser.mly
@@ -49,7 +49,6 @@ let version = (2, 1)
 %nonassoc PFXOP
 %left LBRACE RBRACE
 %nonassoc RELOP
-%nonassoc URELOP
 
 %start main value
 %type <string -> OpamParserTypes.FullPos.opamfile> main

--- a/src/opamBaseParser.mly
+++ b/src/opamBaseParser.mly
@@ -41,13 +41,11 @@ let version = (2, 1)
 %token <OpamParserTypes.FullPos.pfxop_kind> PFXOP
 %token <OpamParserTypes.FullPos.env_update_op_kind> ENVOP
 
-%left COLON
 %left ATOM
 %left OR
 %left AND
-%nonassoc ENVOP
 %nonassoc PFXOP
-%left LBRACE RBRACE
+%left LBRACE
 %nonassoc RELOP
 
 %start main value

--- a/src/opamLexer.mll
+++ b/src/opamLexer.mll
@@ -84,7 +84,7 @@ let char_for_hexadecimal_code lexbuf i =
 (* Some hash-consing for strings *)
 module HS =
   Weak.Make(struct include String let hash = Hashtbl.hash let equal = (=) end)
-let hm = HS.create 317
+let hm = Domain.DLS.new_key (fun () -> HS.create 317)
 
 
 let buffer_rule r lb =
@@ -93,7 +93,7 @@ let buffer_rule r lb =
   r b lb ;
   (* buffer start position, instead of last lexem position *)
   lb.Lexing.lex_start_p <- pos;
-  HS.merge hm (Buffer.contents b)
+  HS.merge (Domain.DLS.get hm) (Buffer.contents b)
 }
 
 let eol = '\r'? '\n'
@@ -131,7 +131,7 @@ rule token = parse
 | "true" { BOOL true }
 | "false"{ BOOL false }
 | int    { INT (int_of_string (Lexing.lexeme lexbuf)) }
-| ident  { IDENT (HS.merge hm (Lexing.lexeme lexbuf)) }
+| ident  { IDENT (HS.merge (Domain.DLS.get hm) (Lexing.lexeme lexbuf)) }
 | relop  { RELOP (FullPos.relop (Lexing.lexeme lexbuf)) }
 | '&'    { AND }
 | '|'    { OR }

--- a/tests/hygiene/dune
+++ b/tests/hygiene/dune
@@ -6,7 +6,7 @@
   (flags :standard (:include flags.sexp))
   (action (run %{test} %{version:opam-file-format})))
 
-(ocamlyacc OpamBaseParser)
+(menhir (modules OpamBaseParser) (infer false))
 
 (rule
   (with-stdout-to OpamBaseParser.mly


### PR DESCRIPTION
PR on top of #51 

This PR changes the parser from ocamlyacc to menhir. I made this sit on top of #51 for simplicity sake.

If merged I believe we should release this as `opam-file-format.2.2.0`